### PR TITLE
Add build helpers and instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ if(NOT CMAKE_BUILD_TYPE)
   )
 endif()
 
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 add_subdirectory(third_party/glog)
 add_subdirectory(third_party/googletest)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM nvidia/cuda:11.3.1-cudnn8-devel-ubuntu18.04 as dev-base
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git && \
+    rm -rf /var/lib/apt/lists/*
+ENV PATH /opt/conda/bin:$PATH
+
+FROM dev-base as conda
+ENV PYTHON_VER=3.9.5
+RUN curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    /opt/conda/bin/conda install -y python=${PYTHON_VER} pytorch cmake ninja -c pytorch && \
+    /opt/conda/bin/conda clean -ya
+
+ENV CMAKE_PREFIX_PATH="/opt/conda/bin/../:/opt/conda/lib/python3.9/site-packages/torch/share/cmake"
+
+CMD bash

--- a/README.md
+++ b/README.md
@@ -13,6 +13,52 @@ It currently consists of two parts:
 
 Both APIs are available in both C++ (raw device pointers) and Python/PyTorch (PyTorch tensor) API forms.
 
+## Building
+
+Clone this repo using
+
+```shell
+git clone --recursive https://github.com/facebookresearch/dietgpu
+cd dietgpu
+```
+
+Then the simplest way is to use the included Dockerfile, which installs the PyTorch dependencies *and* uses NVIDIA's dev image as a base (for the CUDA dependencies):
+
+```shell
+docker build -t dietgpu .
+docker run --privileged --runtime=nvidia --rm -v $(pwd):/dietgpu -it dietgpu:latest
+```
+
+Note you need NVIDIA's container runtime installed (if on Fedora consult this [Github issue](https://github.com/NVIDIA/nvidia-docker/issues/706#issuecomment-851816502)).
+
+Then do the standard CMake thing:
+
+```shell
+cd dietgpu; mkdir build; cd build;
+cmake .. -G Ninja
+cmake --build . --target all
+```
+
+If you get complaints about `TorchConfig.cmake` then your `CMAKE_PREFIX_PATH` doesn't have the right paths; run
+
+```shell
+python -c 'import torch;print(torch.utils.cmake_prefix_path)'
+```
+
+to discover where `TorchConfig.cmake` lives (and add that path to your `CMAKE_PREFIX_PATH`).
+In general, you can run
+```shell
+export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../:$(python -c 'import torch;print(torch.utils.cmake_prefix_path)')"
+```
+
+If you get complaints about `/dietgpu/third_party/glog... does not contain a CMakeLists.txt file.` then you didn't pull the submodules; run
+
+```shell
+git submodule sync
+git submodule update --init --recursive --jobs 0
+```
+and try again.
+
 ## Library rationale
 
 As on-device global memory / HBM bandwidth continues to improve at a faster rate than CPU/GPU interconnect or server-to-server networking bandwidth, spending GPU compute and gmem bandwidth to save on data sent over interconnects is becoming more advantageous. DietGPU aims to target this gap.

--- a/dietgpu/utils/CMakeLists.txt
+++ b/dietgpu/utils/CMakeLists.txt
@@ -9,8 +9,6 @@ target_include_directories(dietgpu_utils PUBLIC
 )
 target_link_libraries(dietgpu_utils PUBLIC
   ${CUDA_LIBRARIES}
-)
-target_link_libraries(dietgpu_utils PRIVATE
   glog::glog
 )
 target_compile_options(dietgpu_utils PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:


### PR DESCRIPTION
Summary:
1. Fix glog dep for utils that was causing "can't find logging.h" error.
2. Set "canonical" build process artifact directory (i.e., $BUILD_DIR/bin).
3. Add Dockerfile (based off of PyTorch's) that can actually build the library.
4. Update readme to include instructions on how to build (along with some gotchas).

Reviewed By: wickedfoo

Differential Revision: D33699450

