### PR TITLE
dietgpu float32 compression support: part 1

### DIFF
--- a/dietgpu/DietGpu.cpp
+++ b/dietgpu/DietGpu.cpp
@@ -24,8 +24,12 @@ FloatType getFloatTypeFromDtype(at::ScalarType t) {
       return FloatType::kFloat16;
     case at::ScalarType::BFloat16:
       return FloatType::kBFloat16;
+    case at::ScalarType::Float:
+      return FloatType::kFloat32;
     default:
-      TORCH_CHECK(t == at::ScalarType::Half || t == at::ScalarType::BFloat16);
+      TORCH_CHECK(
+          t == at::ScalarType::Half || t == at::ScalarType::BFloat16 ||
+          t == at::ScalarType::Float);
       return FloatType::kUndefined;
   }
 }
@@ -36,8 +40,12 @@ at::ScalarType getDtypeFromFloatType(FloatType ft) {
       return at::ScalarType::Half;
     case FloatType::kBFloat16:
       return at::ScalarType::BFloat16;
+    case FloatType::kFloat32:
+      return at::ScalarType::Float;
     default:
-      TORCH_CHECK(ft == FloatType::kFloat16 || ft == FloatType::kBFloat16);
+      TORCH_CHECK(
+          ft == FloatType::kFloat16 || ft == FloatType::kBFloat16 ||
+          ft == FloatType::kFloat32);
       return at::ScalarType::Half;
   }
 }
@@ -535,7 +543,8 @@ int64_t decompress_data_res(
     TORCH_CHECK(tIn.dtype() == torch::kByte);
     if (compressAsFloat) {
       TORCH_CHECK(
-          tOut.dtype() == torch::kFloat16 || tOut.dtype() == torch::kBFloat16);
+          tOut.dtype() == torch::kFloat16 || tOut.dtype() == torch::kBFloat16 ||
+          tOut.dtype() == torch::kFloat32);
     }
 
     inPtrs[i] = tIn.data_ptr();
@@ -692,7 +701,8 @@ int64_t decompress_data_split_size(
   TORCH_CHECK(tOut.is_contiguous());
   if (compressAsFloat) {
     TORCH_CHECK(
-        tOut.dtype() == torch::kFloat16 || tOut.dtype() == torch::kBFloat16);
+        tOut.dtype() == torch::kFloat16 || tOut.dtype() == torch::kBFloat16 ||
+        tOut.dtype() == torch::kFloat32);
   }
 
   auto outSize =

--- a/dietgpu/float/GpuFloatCodec.h
+++ b/dietgpu/float/GpuFloatCodec.h
@@ -18,8 +18,7 @@ enum FloatType {
   kUndefined = 0,
   kFloat16 = 1,
   kBFloat16 = 2,
-  // not yet implemented
-  //  kFloat32 = 3,
+  kFloat32 = 3,
 };
 
 // Returns the maximum possible compressed size in bytes of an array of `size`

--- a/dietgpu/float/GpuFloatDecompress.cuh
+++ b/dietgpu/float/GpuFloatDecompress.cuh
@@ -26,8 +26,11 @@ struct JoinFloat;
 
 template <>
 struct JoinFloat<FloatType::kFloat16> {
-  static __device__ __forceinline__ uint16_t
-  join(uint8_t comp, uint8_t nonComp) {
+  static __device__ __forceinline__
+      typename FloatTypeInfo<FloatType::kFloat16>::WordT
+      join(
+          typename FloatTypeInfo<FloatType::kFloat16>::CompT comp,
+          typename FloatTypeInfo<FloatType::kFloat16>::NonCompT nonComp) {
     uint16_t out = comp;
     out = (out << 8) | ((uint16_t)nonComp);
 
@@ -37,8 +40,11 @@ struct JoinFloat<FloatType::kFloat16> {
 
 template <>
 struct JoinFloat<FloatType::kBFloat16> {
-  static __device__ __forceinline__ uint16_t
-  join(uint8_t comp, uint8_t nonComp) {
+  static __device__ __forceinline__
+      typename FloatTypeInfo<FloatType::kBFloat16>::WordT
+      join(
+          typename FloatTypeInfo<FloatType::kBFloat16>::CompT comp,
+          typename FloatTypeInfo<FloatType::kBFloat16>::NonCompT nonComp) {
     uint32_t lo = (uint32_t)comp * 256U + (uint32_t)nonComp;
     lo <<= 16;
     uint32_t hi = nonComp;
@@ -51,12 +57,24 @@ struct JoinFloat<FloatType::kBFloat16> {
   }
 };
 
+template <>
+struct JoinFloat<FloatType::kFloat32> {
+  static __device__ __forceinline__
+      typename FloatTypeInfo<FloatType::kFloat32>::WordT
+      join(
+          typename FloatTypeInfo<FloatType::kFloat32>::CompT comp,
+          typename FloatTypeInfo<FloatType::kFloat32>::NonCompT nonComp) {
+    uint32_t v = (uint32_t(comp) * 16777216U) + uint32_t(nonComp);
+    return rotateRight(v, 1);
+  }
+};
+
 template <FloatType FT, int Threads>
 __device__ void joinFloatNonAligned(
-    const uint8_t* __restrict__ compIn,
-    const uint8_t* __restrict__ nonCompIn,
+    const typename FloatTypeInfo<FT>::CompT* __restrict__ compIn,
+    const typename FloatTypeInfo<FT>::NonCompT* __restrict__ nonCompIn,
     uint32_t size,
-    uint16_t* __restrict__ out) {
+    typename FloatTypeInfo<FT>::WordT* __restrict__ out) {
   for (uint32_t i = blockIdx.x * Threads + threadIdx.x; i < size;
        i += gridDim.x * Threads) {
     out[i] = JoinFloat<FT>::join(compIn[i], nonCompIn[i]);
@@ -65,17 +83,23 @@ __device__ void joinFloatNonAligned(
 
 template <FloatType FT, int Threads>
 __device__ void joinFloatAligned(
-    const uint8_t* __restrict__ compIn,
-    const uint8_t* __restrict__ nonCompIn,
+    const typename FloatTypeInfo<FT>::CompT* __restrict__ compIn,
+    const typename FloatTypeInfo<FT>::NonCompT* __restrict__ nonCompIn,
     uint32_t size,
-    uint16_t* __restrict__ out) {
-  constexpr int kOuterUnroll = 2;
-  constexpr int kInnerUnroll = sizeof(uint16x8) / sizeof(uint16_t);
-  static_assert(kInnerUnroll == 8, "");
+    typename FloatTypeInfo<FT>::WordT* __restrict__ out) {
+  using WordT = typename FloatTypeInfo<FT>::WordT;
+  using CompT = typename FloatTypeInfo<FT>::CompT;
+  using NonCompT = typename FloatTypeInfo<FT>::NonCompT;
+  using VecT = typename FloatTypeInfo<FT>::VecT;
+  using CompVecT = typename FloatTypeInfo<FT>::CompVecT;
+  using NonCompVecT = typename FloatTypeInfo<FT>::NonCompVecT;
 
-  const uint8x8* compIn8 = (const uint8x8*)compIn;
-  const uint8x8* nonCompIn8 = (const uint8x8*)nonCompIn;
-  uint16x8* out8 = (uint16x8*)out;
+  constexpr int kOuterUnroll = 2;
+  constexpr int kInnerUnroll = sizeof(VecT) / sizeof(WordT);
+
+  const CompVecT* compInV = (const CompVecT*)compIn;
+  const NonCompVecT* nonCompInV = (const NonCompVecT*)nonCompIn;
+  VecT* outV = (VecT*)out;
 
   // Each block handles Threads * kOuterUnroll * kInnerUnroll inputs/outputs at
   // a time, or Threads * kOuterUnroll 16-byte words at a time
@@ -86,24 +110,24 @@ __device__ void joinFloatAligned(
 
   // Handle by block
   uint32_t startBlock = blockIdx.x * kWordsPerBlock;
-  compIn8 += startBlock + threadIdx.x;
-  nonCompIn8 += startBlock + threadIdx.x;
-  out8 += startBlock + threadIdx.x;
+  compInV += startBlock + threadIdx.x;
+  nonCompInV += startBlock + threadIdx.x;
+  outV += startBlock + threadIdx.x;
 
   for (uint32_t b = blockIdx.x; b < fullBlocks; b += gridDim.x,
-                compIn8 += gridDim.x * kWordsPerBlock,
-                nonCompIn8 += gridDim.x * kWordsPerBlock,
-                out8 += gridDim.x * kWordsPerBlock) {
-    uint8x8 comp[kOuterUnroll];
-    uint8x8 nonComp[kOuterUnroll];
+                compInV += gridDim.x * kWordsPerBlock,
+                nonCompInV += gridDim.x * kWordsPerBlock,
+                outV += gridDim.x * kWordsPerBlock) {
+    CompVecT comp[kOuterUnroll];
+    NonCompVecT nonComp[kOuterUnroll];
 
 #pragma unroll
     for (uint32_t i = 0; i < kOuterUnroll; ++i) {
-      comp[i] = compIn8[i * Threads];
-      nonComp[i] = nonCompIn8[i * Threads];
+      comp[i] = compInV[i * Threads];
+      nonComp[i] = nonCompInV[i * Threads];
     }
 
-    uint16x8 v[kOuterUnroll];
+    VecT v[kOuterUnroll];
 
 #pragma unroll
     for (uint32_t i = 0; i < kOuterUnroll; ++i) {
@@ -115,7 +139,7 @@ __device__ void joinFloatAligned(
 
 #pragma unroll
     for (uint32_t i = 0; i < kOuterUnroll; ++i) {
-      out8[i * Threads] = v[i];
+      outV[i * Threads] = v[i];
     }
   }
 
@@ -140,11 +164,16 @@ __global__ void joinFloat(
     OutProvider outProvider,
     uint8_t* __restrict__ outSuccess,
     uint32_t* __restrict__ outSize) {
+  using WordT = typename FloatTypeInfo<FT>::WordT;
+  using CompT = typename FloatTypeInfo<FT>::CompT;
+  using NonCompT = typename FloatTypeInfo<FT>::NonCompT;
+
   int batch = blockIdx.y;
 
-  auto curCompIn = (const uint8_t*)inProviderComp.getBatchStart(batch);
-  auto curNonCompIn = (const uint8_t*)inProviderNonComp.getBatchStart(batch);
-  auto curOut = (uint16_t*)outProvider.getBatchStart(batch);
+  auto curCompIn = (const CompT*)inProviderComp.getBatchStart(batch);
+  auto curHeaderIn =
+      (const GpuFloatHeader*)inProviderNonComp.getBatchStart(batch);
+  auto curOut = (WordT*)outProvider.getBatchStart(batch);
 
   // FIXME: test out capacity
 
@@ -154,17 +183,18 @@ __global__ void joinFloat(
   }
 
   // Get size as a header
-  GpuFloatHeader h = *((const GpuFloatHeader*)curNonCompIn);
+  GpuFloatHeader h = *curHeaderIn;
   assert(h.magic == kGpuFloatHeaderMagic);
 
   auto curSize = h.size;
-  curNonCompIn += sizeof(GpuFloatHeader);
 
   if (outSize && (curSize != outSize[batch])) {
     // Reported size mismatch between ANS decompression and fp unpacking
     assert(false);
     return;
   }
+
+  auto curNonCompIn = (const NonCompT*)(curHeaderIn + 1);
 
   // curCompIn should always be aligned, as we decompress into temporary memory
   auto compUnalignedBytes = getAlignmentRoundUp<sizeof(uint4)>(curCompIn);
@@ -178,8 +208,10 @@ __global__ void joinFloat(
   }
 }
 
-template <typename InProvider>
+template <FloatType FT, typename InProvider>
 struct FloatANSProvider {
+  using FTI = FloatTypeInfo<FT>;
+
   __host__ FloatANSProvider(InProvider& provider) : inProvider_(provider) {}
 
   __device__ void* getBatchStart(uint32_t batch) {
@@ -188,8 +220,9 @@ struct FloatANSProvider {
     GpuFloatHeader h = *((GpuFloatHeader*)p);
     assert(h.magic == kGpuFloatHeaderMagic);
 
-    // This is where the ANS compressed data begins
-    return (void*)(p + sizeof(GpuFloatHeader) + roundUp(h.size, sizeof(uint4)));
+    // Increment the pointer to past the floating point data
+    return (
+        void*)(p + sizeof(GpuFloatHeader) + roundUp(FTI::kNotCompressed * h.size, sizeof(uint4)));
   }
 
   __device__ const void* getBatchStart(uint32_t batch) const {
@@ -198,15 +231,18 @@ struct FloatANSProvider {
     GpuFloatHeader h = *((const GpuFloatHeader*)p);
     assert(h.magic == kGpuFloatHeaderMagic);
 
-    // This is where the ANS compressed data begins
-    return p + sizeof(GpuFloatHeader) + roundUp(h.size, sizeof(uint4));
+    // Increment the pointer to past the floating point data
+    return p + sizeof(GpuFloatHeader) +
+        roundUp(FTI::kNotCompressed * h.size, sizeof(uint4));
   }
 
   InProvider inProvider_;
 };
 
-template <int N>
+template <FloatType FT, int N>
 struct FloatANSProviderInline {
+  using FTI = FloatTypeInfo<FT>;
+
   __host__ FloatANSProviderInline(int num, const void** in) {
     CHECK_LE(num, N);
     for (int i = 0; i < num; ++i) {
@@ -220,8 +256,9 @@ struct FloatANSProviderInline {
     GpuFloatHeader h = *((GpuFloatHeader*)p);
     assert(h.magic == kGpuFloatHeaderMagic);
 
-    // This is where the ANS compressed data begins
-    return (void*)(p + sizeof(GpuFloatHeader) + roundUp(h.size, sizeof(uint4)));
+    // Increment the pointer to past the floating point data
+    return p + sizeof(GpuFloatHeader) +
+        roundUp(FTI::kNotCompressed * h.size, sizeof(uint4));
   }
 
   __device__ const void* getBatchStart(uint32_t batch) const {
@@ -230,8 +267,9 @@ struct FloatANSProviderInline {
     GpuFloatHeader h = *((const GpuFloatHeader*)p);
     assert(h.magic == kGpuFloatHeaderMagic);
 
-    // This is where the ANS compressed data begins
-    return p + sizeof(GpuFloatHeader) + roundUp(h.size, sizeof(uint4));
+    // Increment the pointer to past the floating point data
+    return p + sizeof(GpuFloatHeader) +
+        roundUp(FTI::kNotCompressed * h.size, sizeof(uint4));
   }
 
   const void* in_[N];
@@ -239,7 +277,11 @@ struct FloatANSProviderInline {
 
 template <FloatType FT, uint32_t BlockSize>
 struct JoinFloatWriter {
-  __host__ __device__ JoinFloatWriter(uint16_t* out, const uint8_t* nonComp)
+  using FTI = FloatTypeInfo<FT>;
+
+  __host__ __device__ JoinFloatWriter(
+      typename FTI::WordT* out,
+      const typename FTI::NonCompT* nonComp)
       : out_(out),
         nonComp_(nonComp),
         outBlock_(nullptr),
@@ -255,30 +297,30 @@ struct JoinFloatWriter {
     outBlock_[offset] = JoinFloat<FT>::join(sym, nonComp);
   }
 
+  // The preload is an offset of a NonCompVec4
   __device__ void preload(uint32_t offset) {
     // We can preload this before decompressing all of the ANS compressed data
     // to hide memory latency
-    preload_ = ((uint32_t*)nonCompBlock_)[offset];
+    preload_ = ((typename FTI::NonCompVec4*)nonCompBlock_)[offset];
   }
 
   __device__ void writeVec(uint32_t offset, ANSDecodedTx4 symV) {
-    uint16x4 outV;
+    typename FTI::Vec4 outV;
 #pragma unroll
+    // We always receive 4 decoded values each iteration
+    // FIXME: this is hacky
     for (int i = 0; i < 4; ++i) {
-      auto v = preload_ & 0xff;
-      preload_ >>= 8;
-
-      outV.x[i] = JoinFloat<FT>::join(symV.x[i], v);
+      outV.x[i] = JoinFloat<FT>::join(symV.x[i], preload_.x[i]);
     }
 
-    ((uint16x4*)outBlock_)[offset] = outV;
+    ((typename FTI::Vec4*)outBlock_)[offset] = outV;
   }
 
-  uint32_t preload_;
-  uint16_t* out_;
-  const uint8_t* nonComp_;
-  uint16_t* outBlock_;
-  const uint8_t* nonCompBlock_;
+  typename FTI::NonCompVec4 preload_;
+  typename FTI::WordT* out_;
+  const typename FTI::NonCompT* nonComp_;
+  typename FTI::WordT* outBlock_;
+  const typename FTI::NonCompT* nonCompBlock_;
 };
 
 template <
@@ -288,15 +330,17 @@ template <
     uint32_t BlockSize>
 struct FloatOutProvider {
   using Writer = JoinFloatWriter<FT, BlockSize>;
+  using FTI = FloatTypeInfo<FT>;
 
   __host__ FloatOutProvider(InProvider& inProvider, OutProvider& outProvider)
       : inProvider_(inProvider), outProvider_(outProvider) {}
 
   __device__ Writer getWriter(uint32_t batch) {
     return Writer(
-        (uint16_t*)outProvider_.getBatchStart(batch),
-        (const uint8_t*)inProvider_.getBatchStart(batch) +
-            sizeof(GpuFloatHeader));
+        (typename FTI::WordT*)outProvider_.getBatchStart(batch),
+        (const typename FTI::NonCompT*)
+        // advance past the header
+        (((GpuFloatHeader*)inProvider_.getBatchStart(batch)) + 1));
   }
 
   __device__ uint32_t getBatchSize(uint32_t batch) {
@@ -309,6 +353,7 @@ struct FloatOutProvider {
 
 template <int N, FloatType FT, uint32_t BlockSize>
 struct FloatOutProviderInline {
+  using FTI = FloatTypeInfo<FT>;
   using Writer = JoinFloatWriter<FT, BlockSize>;
 
   __host__ FloatOutProviderInline(
@@ -326,8 +371,9 @@ struct FloatOutProviderInline {
 
   __device__ Writer getWriter(uint32_t batch) {
     return Writer(
-        (uint16_t*)out_[batch],
-        (const uint8_t*)in_[batch] + sizeof(GpuFloatHeader));
+        (typename FTI::WordT*)out_[batch],
+        (const typename FTI::
+             NonCompT*)((const uint8_t*)in_[batch] + sizeof(GpuFloatHeader)));
   }
 
   __device__ uint32_t getBatchSize(uint32_t batch) {
@@ -356,48 +402,44 @@ void floatDecompressDevice(
     //
     // Fused kernel: perform decompression in a single pass
     //
-    auto inProviderANS = FloatANSProvider<InProvider>(inProvider);
+
+#define RUN_FUSED(FT)                                                     \
+  do {                                                                    \
+    auto inProviderANS = FloatANSProvider<FT, InProvider>(inProvider);    \
+    auto outProviderANS =                                                 \
+        FloatOutProvider<InProvider, OutProvider, FT, kDefaultBlockSize>( \
+            inProvider, outProvider);                                     \
+                                                                          \
+    ansDecodeBatch(                                                       \
+        res,                                                              \
+        config.probBits,                                                  \
+        numInBatch,                                                       \
+        inProviderANS,                                                    \
+        outProviderANS,                                                   \
+        outSuccess_dev,                                                   \
+        outSize_dev,                                                      \
+        stream);                                                          \
+  } while (false)
 
     switch (config.floatType) {
-      case kFloat16: {
-        auto outProviderANS = FloatOutProvider<
-            InProvider,
-            OutProvider,
-            FloatType::kFloat16,
-            kDefaultBlockSize>(inProvider, outProvider);
-
-        ansDecodeBatch(
-            res,
-            config.probBits,
-            numInBatch,
-            inProviderANS,
-            outProviderANS,
-            outSuccess_dev,
-            outSize_dev,
-            stream);
-      } break;
-      case kBFloat16: {
-        auto outProviderANS = FloatOutProvider<
-            InProvider,
-            OutProvider,
-            FloatType::kBFloat16,
-            kDefaultBlockSize>(inProvider, outProvider);
-
-        ansDecodeBatch(
-            res,
-            config.probBits,
-            numInBatch,
-            inProviderANS,
-            outProviderANS,
-            outSuccess_dev,
-            outSize_dev,
-            stream);
-      } break;
+      case kFloat16:
+        RUN_FUSED(FloatType::kFloat16);
+        break;
+      case kBFloat16:
+        RUN_FUSED(FloatType::kBFloat16);
+        break;
+      case kFloat32:
+        RUN_FUSED(FloatType::kFloat32);
+        break;
       default:
         CHECK(false);
         break;
     }
-  } else {
+
+#undef RUN_FUSED
+  }
+
+  else {
     //
     // Two pass kernel: decompress the ANS compressed data, then rejoin with
     // uncompressed data
@@ -410,68 +452,65 @@ void floatDecompressDevice(
 
     auto exp_dev = res.alloc<uint8_t>(stream, numInBatch * maxCapacityAligned);
 
-    using InProviderANS = FloatANSProvider<InProvider>;
-    auto inProviderANS = InProviderANS(inProvider);
-
-    using OutProviderANS = BatchProviderStride;
-    auto outProviderANS =
-        OutProviderANS(exp_dev.data(), maxCapacityAligned, maxCapacityAligned);
-
-    ansDecodeBatch(
-        res,
-        config.probBits,
-        numInBatch,
-        inProviderANS,
-        outProviderANS,
-        outSuccess_dev,
-        outSize_dev,
-        stream);
-
-    // Rejoin the rest of the float word
-#define RUN_JOIN(FLOAT_TYPE)                                                 \
-  do {                                                                       \
-    constexpr int kThreads = 256;                                            \
-    auto& props = getCurrentDeviceProperties();                              \
-    int maxBlocksPerSM = 0;                                                  \
-    CUDA_VERIFY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(               \
-        &maxBlocksPerSM,                                                     \
-        joinFloat<                                                           \
-            OutProviderANS,                                                  \
-            InProvider,                                                      \
-            OutProvider,                                                     \
-            FLOAT_TYPE,                                                      \
-            kThreads>,                                                       \
-        kThreads,                                                            \
-        0));                                                                 \
-    uint32_t maxGrid = maxBlocksPerSM * props.multiProcessorCount;           \
-    uint32_t perBatchGrid = divUp(maxGrid, numInBatch);                      \
-    if ((perBatchGrid * numInBatch > maxGrid) && perBatchGrid > 1) {         \
-      perBatchGrid -= 1;                                                     \
-    }                                                                        \
-    auto grid = dim3(perBatchGrid, numInBatch);                              \
-                                                                             \
-    joinFloat<OutProviderANS, InProvider, OutProvider, FLOAT_TYPE, kThreads> \
-        <<<grid, kThreads, 0, stream>>>(                                     \
-            outProviderANS,                                                  \
-            inProvider,                                                      \
-            outProvider,                                                     \
-            outSuccess_dev,                                                  \
-            outSize_dev);                                                    \
+#define RUN_DECODE(FT)                                                    \
+  do {                                                                    \
+    using InProviderANS = FloatANSProvider<FT, InProvider>;               \
+    auto inProviderANS = InProviderANS(inProvider);                       \
+                                                                          \
+    using OutProviderANS = BatchProviderStride;                           \
+    auto outProviderANS = OutProviderANS(                                 \
+        exp_dev.data(), maxCapacityAligned, maxCapacityAligned);          \
+                                                                          \
+    ansDecodeBatch(                                                       \
+        res,                                                              \
+        config.probBits,                                                  \
+        numInBatch,                                                       \
+        inProviderANS,                                                    \
+        outProviderANS,                                                   \
+        outSuccess_dev,                                                   \
+        outSize_dev,                                                      \
+        stream);                                                          \
+                                                                          \
+    constexpr int kThreads = 256;                                         \
+    auto& props = getCurrentDeviceProperties();                           \
+    int maxBlocksPerSM = 0;                                               \
+    CUDA_VERIFY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(            \
+        &maxBlocksPerSM,                                                  \
+        joinFloat<OutProviderANS, InProvider, OutProvider, FT, kThreads>, \
+        kThreads,                                                         \
+        0));                                                              \
+    uint32_t maxGrid = maxBlocksPerSM * props.multiProcessorCount;        \
+    uint32_t perBatchGrid = divUp(maxGrid, numInBatch);                   \
+    if ((perBatchGrid * numInBatch > maxGrid) && perBatchGrid > 1) {      \
+      perBatchGrid -= 1;                                                  \
+    }                                                                     \
+    auto grid = dim3(perBatchGrid, numInBatch);                           \
+                                                                          \
+    joinFloat<OutProviderANS, InProvider, OutProvider, FT, kThreads>      \
+        <<<grid, kThreads, 0, stream>>>(                                  \
+            outProviderANS,                                               \
+            inProvider,                                                   \
+            outProvider,                                                  \
+            outSuccess_dev,                                               \
+            outSize_dev);                                                 \
   } while (false)
 
     switch (config.floatType) {
       case kFloat16:
-        RUN_JOIN(kFloat16);
+        RUN_DECODE(FloatType::kFloat16);
         break;
       case kBFloat16:
-        RUN_JOIN(kBFloat16);
+        RUN_DECODE(FloatType::kBFloat16);
+        break;
+      case kFloat32:
+        RUN_DECODE(FloatType::kFloat32);
         break;
       default:
-        assert(false);
+        CHECK(false);
         break;
     }
 
-#undef RUN_JOIN
+#undef RUN_DECODE
   }
 
   CUDA_TEST_ERROR();

--- a/dietgpu/float/GpuFloatUtils.cuh
+++ b/dietgpu/float/GpuFloatUtils.cuh
@@ -24,6 +24,10 @@ struct __align__(16) GpuFloatHeader {
 
 static_assert(sizeof(GpuFloatHeader) == 16, "");
 
+struct __align__(16) uint32x4 {
+  uint32_t x[4];
+};
+
 struct __align__(16) uint16x8 {
   uint16_t x[8];
 };
@@ -36,16 +40,83 @@ struct __align__(8) uint8x8 {
   uint8_t x[8];
 };
 
+struct __align__(4) uint8x4 {
+  uint8_t x[4];
+};
+
+// Convert FloatType to word size/type
+template <FloatType FT>
+struct FloatTypeInfo;
+
+template <>
+struct FloatTypeInfo<FloatType::kFloat16> {
+  using WordT = uint16_t;
+  using CompT = uint8_t;
+  using NonCompT = uint8_t;
+
+  // How many bytes are not compressed?
+  static constexpr size_t kNotCompressed = 1;
+
+  // 16 byte vector type
+  using VecT = uint16x8;
+  using CompVecT = uint8x8;
+  using NonCompVecT = uint8x8;
+
+  using Vec4 = uint16x4;
+  using CompVec4 = uint8x4;
+  using NonCompVec4 = uint8x4;
+};
+
+template <>
+struct FloatTypeInfo<FloatType::kBFloat16> {
+  using WordT = uint16_t;
+  using CompT = uint8_t;
+  using NonCompT = uint8_t;
+
+  // How many bytes are not compressed?
+  static constexpr size_t kNotCompressed = 1;
+
+  // 16 byte vector type
+  using VecT = uint16x8;
+  using CompVecT = uint8x8;
+  using NonCompVecT = uint8x8;
+
+  using Vec4 = uint16x4;
+  using CompVec4 = uint8x4;
+  using NonCompVec4 = uint8x4;
+};
+
+template <>
+struct FloatTypeInfo<FloatType::kFloat32> {
+  using WordT = uint32_t;
+  using CompT = uint8_t;
+  using NonCompT = uint32_t;
+
+  // How many bytes are not compressed?
+  // FIXME: pack to 3
+  static constexpr size_t kNotCompressed = 4;
+
+  // 16 byte vector type
+  using VecT = uint32x4;
+  using CompVecT = uint8x4;
+  using NonCompVecT = uint32x4;
+
+  using Vec4 = uint32x4;
+  using CompVec4 = uint8x4;
+  // FIXME
+  using NonCompVec4 = uint32x4;
+};
+
 inline size_t getWordSizeFromFloatType(FloatType ft) {
   switch (ft) {
     case FloatType::kFloat16:
     case FloatType::kBFloat16:
       return sizeof(uint16_t);
-    // case FloatType::kFloat32:
-    //   return sizeof(uint32_t);
+    case FloatType::kFloat32:
+      return sizeof(uint32_t);
     default:
-      CHECK(ft == FloatType::kFloat16 || ft == FloatType::kBFloat16);
-      return sizeof(uint16_t);
+      CHECK(false);
+      return 0;
   }
 }
 

--- a/dietgpu/float_test.py
+++ b/dietgpu/float_test.py
@@ -52,7 +52,7 @@ class TestFloatCodec(unittest.TestCase):
         dev = torch.device("cuda:0")
         temp_mem = torch.empty([64 * 1024 * 1024], dtype=torch.uint8, device=dev)
 
-        for dt in [torch.bfloat16, torch.float16]:
+        for dt in [torch.bfloat16, torch.float16, torch.float32]:
             for tm in [False, True]:
                 ts = [
                     torch.normal(0, 1.0, [i], dtype=dt, device=dev)
@@ -67,7 +67,7 @@ class TestFloatCodec(unittest.TestCase):
         dev = torch.device("cuda:0")
         temp_mem = torch.empty([64 * 1024 * 1024], dtype=torch.uint8, device=dev)
 
-        for dt in [torch.bfloat16, torch.float16]:
+        for dt in [torch.bfloat16, torch.float16, torch.float32]:
             for tm in [False, True]:
                 ts = [torch.normal(0, 1.0, [123456789], dtype=dt, device=dev)]
                 if tm:
@@ -77,7 +77,7 @@ class TestFloatCodec(unittest.TestCase):
 
     def test_simple(self):
         dev = torch.device("cuda:0")
-        for dt in [torch.bfloat16, torch.float16]:
+        for dt in [torch.bfloat16, torch.float16, torch.float32]:
             ts = [
                 torch.normal(0, 1.0, [i], dtype=dt, device=dev)
                 for i in [10000, 100000, 1000000]
@@ -85,10 +85,12 @@ class TestFloatCodec(unittest.TestCase):
 
             cts = torch.ops.dietgpu.compress_data_simple(True, ts)
             for before, after in zip(ts, cts):
-                assert (
-                    before.numel() * before.element_size()
-                    > after.numel() * after.element_size()
-                )
+                # FIXME: float32 compression
+                if dt != torch.float32:
+                    assert (
+                        before.numel() * before.element_size()
+                        > after.numel() * after.element_size()
+                    )
 
             dts = torch.ops.dietgpu.decompress_data_simple(True, cts)
             for orig, after in zip(ts, dts):
@@ -109,7 +111,7 @@ class TestFloatCodec(unittest.TestCase):
         dev = torch.device("cuda:0")
         temp_mem = torch.empty([64 * 1024 * 1024], dtype=torch.uint8, device=dev)
 
-        for dt in [torch.bfloat16, torch.float16]:
+        for dt in [torch.bfloat16, torch.float16, torch.float32]:
             for align16 in [True, False]:
                 for tries in range(5):
                     batch_size = random.randrange(1, 15)
@@ -144,7 +146,7 @@ class TestFloatCodec(unittest.TestCase):
         dev = torch.device("cuda:0")
         temp_mem = torch.empty([64 * 1024 * 1024], dtype=torch.uint8, device=dev)
 
-        for dt in [torch.bfloat16, torch.float16]:
+        for dt in [torch.bfloat16, torch.float16, torch.float32]:
             for align16 in [True, False]:
                 for tries in range(5):
                     batch_size = random.randrange(1, 15)


### PR DESCRIPTION
Summary:
This diff contains some prerequisites for losslessly compressing float32 data. We can now accept float32 dtype data, but right now the kernels that pack the uncompressed portion have not been adjusted to allow storing 3 bytes of data per word, so instead we store the uncompressed 3 bytes as a 4 byte word.

As a result, this diff does not actually compress float32 data, but instead expands it. A subsequent diff will either allow for the split/join float kernel to handle 3 byte words, or perhaps it will be more efficient to allow interleaving 2 ANS compressors in the same data stream using different table data, which would allow compressing 2 byte words of data with statistics independently computed for each byte.

This diff also removes the "min symbol" usage from the compressor and decompressor. The original idea for this was to perhaps allow for optimizations when there are <= 32 or 64 symbols by storing table data in registers, but this proved impractical. Additionally only the symbols that are present need be stored in the ANS header data, but entries for all 256 possible symbols are currently stored. We still compute the min and num symbols which can bound the data being stored, but we aren't doing anything with them. A subsequent diff might allow for storing a truncated symbol table if all 256 possible symbols are not in fact encountered. Removing this min symbol usage provides a small speedup and will make it easier to interleave 2 ANS compressors in the same stream by removing one less thing that needs to be handled.

Reviewed By: jspark1105

Differential Revision: D34157690

