### PR TITLE
dietgpu full float32 support

### DIFF
--- a/dietgpu/ans/ANSTest.cu
+++ b/dietgpu/ans/ANSTest.cu
@@ -189,7 +189,7 @@ void runBatchStride(
 
   ansEncodeBatchStride(
       res,
-      prec,
+      ANSCodecConfig(prec),
       numInBatch,
       orig_dev.data(),
       inBatchSize,
@@ -215,7 +215,7 @@ void runBatchStride(
   // sure the compressed size is accurate
   ansDecodeBatchStride(
       res,
-      prec,
+      ANSCodecConfig(prec),
       numInBatch,
       enc_dev.data(),
       outBatchStride,

--- a/dietgpu/ans/BatchPrefixSumTest.cu
+++ b/dietgpu/ans/BatchPrefixSumTest.cu
@@ -55,8 +55,7 @@ TEST(BatchPrefixSum, OneLevel) {
   auto gen = std::mt19937(10);
   auto nbDist = std::uniform_int_distribution<uint32_t>(1, 20);
 
-  for (auto batchSize :
-       {1, 10, 32, 33, 64, 65, 128, 129, 256, 257, 512, 513, 1024}) {
+  for (auto batchSize : {1, 10, 32, 33, 64, 65, 128, 129, 256, 257, 512}) {
     auto numInBatch = nbDist(gen);
 
     auto data = makeSequence(numInBatch, batchSize, nbDist(gen));
@@ -89,11 +88,11 @@ TEST(BatchPrefixSum, TwoLevel) {
   auto stream = CudaStream::makeNonBlocking();
 
   auto batchSizes = std::vector<int>{
-      1025, 2047, 2048, 4096, 4097, 10000, 100000, 1024 * 1024};
+      513, 1024, 2047, 2048, 4096, 4097, 10000, 100000, 512 * 512};
 
   auto gen = std::mt19937(10);
   auto nbDist = std::uniform_int_distribution<uint32_t>(1, 20);
-  auto bsDist = std::uniform_int_distribution<uint32_t>(1025, 1024 * 1024);
+  auto bsDist = std::uniform_int_distribution<uint32_t>(513, 512 * 512);
 
   for (int i = 0; i < 10; ++i) {
     batchSizes.push_back(bsDist(gen));

--- a/dietgpu/ans/BatchProvider.cuh
+++ b/dietgpu/ans/BatchProvider.cuh
@@ -25,12 +25,12 @@ struct BatchWriter {
     outBlock_[offset] = sym;
   }
 
-  template <typename Vec>
-  inline __device__ void writeVec(uint32_t offset, Vec symV) {
-    ((Vec*)outBlock_)[offset] = symV;
-  }
+  // template <typename Vec>
+  // inline __device__ void writeVec(uint32_t offset, Vec symV) {
+  //   ((Vec*)outBlock_)[offset] = symV;
+  // }
 
-  __device__ void preload(uint32_t offset) {}
+  // __device__ void preload(uint32_t offset) {}
 
   uint8_t* out_;
   uint8_t* outBlock_;

--- a/dietgpu/ans/GpuANSCodec.h
+++ b/dietgpu/ans/GpuANSCodec.h
@@ -15,7 +15,23 @@ namespace dietgpu {
 // Required minimum alignment in bytes of all data to be compressed in the batch
 constexpr int kANSRequiredAlignment = 4;
 
+// Default number of probability quantization bits to use, if an alternative is
+// not specified
+constexpr int kANSDefaultProbBits = 10;
+
 uint32_t getMaxCompressedSize(uint32_t uncompressedBytes);
+
+struct ANSCodecConfig {
+  inline ANSCodecConfig() : probBits(kANSDefaultProbBits) {}
+
+  inline ANSCodecConfig(int pb) : probBits(pb) {}
+
+  // What the ANS probability accuracy is; all symbols have quantized
+  // probabilities of 1/2^probBits.
+  // 9, 10, 11 are only valid values. When in doubt, use 10 (e.g., all symbol
+  // probabilities are one of {1/1024, 2/1024, ..., 1023/1024, 1024/1024})
+  int probBits;
+};
 
 //
 // Encode
@@ -23,8 +39,9 @@ uint32_t getMaxCompressedSize(uint32_t uncompressedBytes);
 
 void ansEncodeBatchStride(
     StackDeviceMemory& res,
-    // Quantized minimum symbol probability (1/2^probBits)
-    int probBits,
+    // Compression configuration
+    const ANSCodecConfig& config,
+
     // Number of separate, independent compression problems
     uint32_t numInBatch,
 
@@ -57,8 +74,9 @@ void ansEncodeBatchStride(
 
 void ansEncodeBatchPointer(
     StackDeviceMemory& res,
-    // Quantized minimum symbol probability (1/2^probBits)
-    int probBits,
+    // Compression configuration
+    const ANSCodecConfig& config,
+
     // Number of separate, independent compression problems
     uint32_t numInBatch,
 
@@ -86,8 +104,10 @@ void ansEncodeBatchPointer(
 
 void ansEncodeBatchSplitSize(
     StackDeviceMemory& res,
-    // Quantized minimum symbol probability (1/2^probBits)
-    int probBits,
+
+    // Compression configuration
+    const ANSCodecConfig& config,
+
     // Number of separate, independent compression problems
     uint32_t numInBatch,
 
@@ -124,8 +144,10 @@ void ansEncodeBatchSplitSize(
 
 void ansDecodeBatchStride(
     StackDeviceMemory& res,
-    // Quantized minimum symbol probability (1/2^probBits)
-    int probBits,
+
+    // Expected compression configuration (we verify this upon decompression)
+    const ANSCodecConfig& config,
+
     // Number of separate, independent decompression problems
     uint32_t numInBatch,
 
@@ -180,8 +202,10 @@ void ansDecodeBatchStride(
 
 void ansDecodeBatchPointer(
     StackDeviceMemory& res,
-    // Expected quantized minimum symbol probability (1/2^probBits)
-    int probBits,
+
+    // Expected compression configuration (we verify this upon decompression)
+    const ANSCodecConfig& config,
+
     // Number of separate, independent decompression problems
     uint32_t numInBatch,
 
@@ -215,8 +239,10 @@ void ansDecodeBatchPointer(
 
 void ansDecodeBatchSplitSize(
     StackDeviceMemory& res,
-    // Expected quantized minimum symbol probability (1/2^probBits)
-    int probBits,
+
+    // Expected compression configuration (we verify this upon decompression)
+    const ANSCodecConfig& config,
+
     // Number of separate, independent compression problems
     uint32_t numInBatch,
 

--- a/dietgpu/ans/GpuANSDecode.cu
+++ b/dietgpu/ans/GpuANSDecode.cu
@@ -19,7 +19,7 @@ namespace dietgpu {
 
 void ansDecodeBatchStride(
     StackDeviceMemory& res,
-    int probBits,
+    const ANSCodecConfig& config,
     uint32_t numInBatch,
     const void* in_dev,
     uint32_t inPerBatchStride,
@@ -35,7 +35,7 @@ void ansDecodeBatchStride(
 
   ansDecodeBatch(
       res,
-      probBits,
+      config,
       numInBatch,
       inProvider,
       outProvider,
@@ -46,7 +46,7 @@ void ansDecodeBatchStride(
 
 void ansDecodeBatchPointer(
     StackDeviceMemory& res,
-    int probBits,
+    const ANSCodecConfig& config,
     uint32_t numInBatch,
     const void** in,
     void** out,
@@ -66,7 +66,7 @@ void ansDecodeBatchPointer(
 
     ansDecodeBatch(
         res,
-        probBits,
+        config,
         numInBatch,
         inProvider,
         outProvider,
@@ -111,7 +111,7 @@ void ansDecodeBatchPointer(
 
   ansDecodeBatch(
       res,
-      probBits,
+      config,
       numInBatch,
       inProvider,
       outProvider,
@@ -122,7 +122,7 @@ void ansDecodeBatchPointer(
 
 void ansDecodeBatchSplitSize(
     StackDeviceMemory& res,
-    int probBits,
+    const ANSCodecConfig& config,
     uint32_t numInBatch,
     const void** in,
     void* out_dev,
@@ -184,7 +184,7 @@ void ansDecodeBatchSplitSize(
 
   ansDecodeBatch(
       res,
-      probBits,
+      config,
       numInBatch,
       inProvider,
       outProvider,

--- a/dietgpu/ans/GpuANSEncode.cu
+++ b/dietgpu/ans/GpuANSEncode.cu
@@ -26,7 +26,7 @@ uint32_t getMaxCompressedSize(uint32_t uncompressedBytes) {
 
 void ansEncodeBatchStride(
     StackDeviceMemory& res,
-    int probBits,
+    const ANSCodecConfig& config,
     uint32_t numInBatch,
     const void* in_dev,
     uint32_t inPerBatchSize,
@@ -42,7 +42,7 @@ void ansEncodeBatchStride(
 
   ansEncodeBatchDevice(
       res,
-      probBits,
+      config,
       numInBatch,
       inProvider,
       histogram_dev,
@@ -54,7 +54,7 @@ void ansEncodeBatchStride(
 
 void ansEncodeBatchPointer(
     StackDeviceMemory& res,
-    int probBits,
+    const ANSCodecConfig& config,
     uint32_t numInBatch,
     const void** in,
     const uint32_t* inSize,
@@ -102,7 +102,7 @@ void ansEncodeBatchPointer(
 
   ansEncodeBatchDevice(
       res,
-      probBits,
+      config,
       numInBatch,
       inProvider,
       histogram_dev,
@@ -114,7 +114,7 @@ void ansEncodeBatchPointer(
 
 void ansEncodeBatchSplitSize(
     StackDeviceMemory& res,
-    int probBits,
+    const ANSCodecConfig& config,
     uint32_t numInBatch,
     const void* in_dev,
     const uint32_t* inSplitSizes,
@@ -168,7 +168,7 @@ void ansEncodeBatchSplitSize(
 
   ansEncodeBatchDevice(
       res,
-      probBits,
+      config,
       numInBatch,
       inProvider,
       histogram_dev,

--- a/dietgpu/ans/GpuANSUtils.cuh
+++ b/dietgpu/ans/GpuANSUtils.cuh
@@ -48,8 +48,7 @@ constexpr ANSStateT kANSStartState = ANSStateT(1)
 constexpr ANSStateT kANSMinState = ANSStateT(1)
     << (kANSStateBits - kANSEncodedBits);
 
-constexpr uint32_t kWarpHeaderMagic = 0x1234f0f0;
-constexpr uint32_t kCoalescedHeaderMagic = 0x5c;
+constexpr uint32_t kCoalescedHeaderMagic = 0xa5;
 
 // Each block of compressed data (either coalesced or uncoalesced) is aligned to
 // this number of bytes and has a valid (if not all used) segment with this

--- a/dietgpu/float/FloatTest.cu
+++ b/dietgpu/float/FloatTest.cu
@@ -214,8 +214,13 @@ void runBatchPointerTest(
 
   for (int i = 0; i < orig.size(); ++i) {
     if (orig[i] != dec[i]) {
-      std::cout << "mismatch at " << i << " / " << orig.size() << ": "
-                << orig[i] << " " << dec[i] << "\n";
+      printf(
+          "mismatch at %d / %d: 0x%08X 0x%08X\n",
+          i,
+          (int)orig.size(),
+          orig[i],
+          dec[i]);
+      break;
     }
   }
 
@@ -247,13 +252,14 @@ void runBatchPointerTest(
     StackDeviceMemory& res,
     FloatType ft,
     int probBits,
-    int numInBatch) {
+    int numInBatch,
+    uint32_t multipleOf = 1) {
   std::mt19937 gen(10 + numInBatch);
   std::uniform_int_distribution<uint32_t> dist(1, 10000);
 
   auto batchSizes = std::vector<uint32_t>(numInBatch);
   for (auto& v : batchSizes) {
-    v = dist(gen);
+    v = roundUp(dist(gen), multipleOf);
   }
 
   runBatchPointerTest(res, ft, probBits, batchSizes);
@@ -267,6 +273,9 @@ TEST(FloatTest, Batch) {
     for (auto probBits : {9, 10}) {
       for (auto numInBatch : {1, 3, 16, 23}) {
         runBatchPointerTest(res, ft, probBits, numInBatch);
+        // Also test the case where there is uniform 16 byte alignment across
+        // all batches
+        runBatchPointerTest(res, ft, probBits, numInBatch, 16);
       }
     }
   }

--- a/dietgpu/float/GpuFloatCodec.h
+++ b/dietgpu/float/GpuFloatCodec.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cuda.h>
+#include "dietgpu/ans/GpuANSCodec.h"
 
 namespace dietgpu {
 
@@ -31,19 +32,19 @@ uint32_t getMaxFloatCompressedSize(FloatType floatType, uint32_t size);
 
 struct FloatCodecConfig {
   inline FloatCodecConfig()
-      : floatType(FloatType::kFloat16), probBits(10), is16ByteAligned(false) {}
+      : floatType(FloatType::kFloat16), is16ByteAligned(false) {}
 
-  inline FloatCodecConfig(FloatType ft, int pb, bool align)
-      : floatType(ft), probBits(pb), is16ByteAligned(align) {}
+  inline FloatCodecConfig(
+      FloatType ft,
+      const ANSCodecConfig& ansConf,
+      bool align)
+      : floatType(ft), ansConfig(ansConf), is16ByteAligned(align) {}
 
   // What kind of floats are we compressing/decompressing?
   FloatType floatType;
 
-  // What the ANS probability accuracy is; all symbols have quantized
-  // probabilities of 1/2^probBits.
-  // 9, 10, 11 are only valid values. When in doubt, use 10 (e.g., all symbol
-  // probabilities are one of {1/1024, 2/1024, ..., 1023/1024, 1024/1024})
-  int probBits;
+  // ANS entropy coder parameters
+  ANSCodecConfig ansConfig;
 
   // Are all all float input pointers/offsets (compress) or output
   // pointers/offsets (decompress) are aligned to 16 bytes?

--- a/dietgpu/float/GpuFloatCompress.cu
+++ b/dietgpu/float/GpuFloatCompress.cu
@@ -24,27 +24,24 @@ uint32_t getMaxFloatCompressedSize(FloatType floatType, uint32_t size) {
   // kNotCompressed bytes per float are simply stored uncompressed
   // rounded up to 16 bytes to ensure alignment of the following ANS data
   // portion
-  uint32_t floatBytes = 0;
+  uint32_t baseSize = sizeof(GpuFloatHeader) + getMaxCompressedSize(size);
 
   switch (floatType) {
     case kFloat16:
-      floatBytes = FloatTypeInfo<FloatType::kFloat16>::kNotCompressed;
+      baseSize += FloatTypeInfo<FloatType::kFloat16>::getUncompDataSize(size);
       break;
     case kBFloat16:
-      floatBytes = FloatTypeInfo<FloatType::kBFloat16>::kNotCompressed;
+      baseSize += FloatTypeInfo<FloatType::kBFloat16>::getUncompDataSize(size);
       break;
     case kFloat32:
-      floatBytes = FloatTypeInfo<FloatType::kFloat32>::kNotCompressed;
+      baseSize += FloatTypeInfo<FloatType::kFloat32>::getUncompDataSize(size);
       break;
     default:
       CHECK(false);
       break;
   }
 
-  // Include size of GpuFloatHeader which is at the beginning of the compressed
-  // data, plus the estimate of the ANS compressed portion of the data
-  return sizeof(GpuFloatHeader) + getMaxCompressedSize(size) +
-      roundUp(size * floatBytes, sizeof(uint4));
+  return baseSize;
 }
 
 void floatCompress(


### PR DESCRIPTION
Summary:
This diff finishes adding full float32 compression support to dietgpu.

The 8 bit exponent is compressed via ANS, while the sign and significand bits are simply stored concatenated. At best we can compress to ~75% of original size. There is no zero compression implemented yet.

The format of the data to compress N float32 values deals with the fact that the uncompressed data is 3 bytes per float word, but there is no native 3 byte load/store:

```
- GpuFloatHeader (16 bytes)
- uint16 x N uncompressed data
  (N uint16 words containing the 2 low bytes of the 24 bit concatenated sign and significand)
- uint16 x (N - roundUp(N, 8)) padding
  (padding to ensure 16 byte alignment for subsequent fields)
- uint8 x N uncompressed data
  (N uint8 words containing the high 1 byte of the 24 bit concatenated sign and significand)
- uint8 x (N - roundUp(N, 16)) padding
  (padding to ensure 16 byte alignment for subsequent fields)
- GpuANSHeader (16 bytes)
<<< ANS compression data >>>
```

In order to implement this, I have temporary removed the vectorized ANS compressor and decompressor code (whereby each lane in a warp handles a contiguous block of 4 x uint8 words). This was possibly a premature optimization and will be revisited when I evaluate fused kernels.

Removing ANS vectorization hurts performance a bit:

**Before diff (baseline)**
```
Compressing [128 * 512 * 1024] torch.bfloat16
comp   time 0.504 ms B/W 266.4 GB/s, compression 134217728 B -> 90459584 B (0.6740x)
decomp time 0.403 ms B/W 333.4 GB/s
Compressing [128, [512 * 1024]] torch.bfloat16
comp   time 0.436 ms B/W 307.9 GB/s, compression 134217728 B -> 90435584 B (0.6738x)
decomp time 0.432 ms B/W 310.9 GB/s
Compressing [128 * 512 * 1024] torch.float16
comp   time 0.563 ms B/W 238.5 GB/s, compression 134217728 B -> 115520768 B (0.8607x)
decomp time 0.491 ms B/W 273.4 GB/s
Compressing [128, [512 * 1024]] torch.float16
comp   time 0.519 ms B/W 258.8 GB/s, compression 134217728 B -> 115548160 B (0.8609x)
decomp time 0.524 ms B/W 256.1 GB/s

```

**After diff (float32 + no ANS vectorization)**
```
Compressing [128 * 512 * 1024] torch.bfloat16
comp   time 0.481 ms B/W 279.0 GB/s, compression 134217728 B -> 90452656 B (0.6739x)
decomp time 0.511 ms B/W 262.6 GB/s
Compressing [128, [512 * 1024]] torch.bfloat16
comp   time 0.413 ms B/W 324.7 GB/s, compression 134217728 B -> 90476544 B (0.6741x)
decomp time 0.532 ms B/W 252.5 GB/s
Compressing [128 * 512 * 1024] torch.float16
comp   time 0.594 ms B/W 226.1 GB/s, compression 134217728 B -> 115516560 B (0.8607x)
decomp time 0.508 ms B/W 264.0 GB/s
Compressing [128, [512 * 1024]] torch.float16
comp   time 0.532 ms B/W 252.1 GB/s, compression 134217728 B -> 115558400 B (0.8610x)
decomp time 0.551 ms B/W 243.8 GB/s
Compressing [128 * 512 * 1024] torch.float32
comp   time 0.684 ms B/W 392.4 GB/s, compression 268435456 B -> 224653424 B (0.8369x)
decomp time 0.606 ms B/W 443.1 GB/s
Compressing [128, [512 * 1024]] torch.float32
comp   time 0.566 ms B/W 474.5 GB/s, compression 268435456 B -> 224647168 B (0.8369x)
decomp time 0.643 ms B/W 417.6 GB/s
```

Other changes:

- the batch prefix sum code no longer worked on batches larger than 512, seemingly due to our change from CUDA 11.1 to CUDA 11.4. I haven't investigated this in detail, but I think CUB register usage is going crazy (everything is being unrolled). This is now fixed by restricting batch prefix sum blocks to 512 max threads.

Differential Revision: D34811429

