### PR TITLE
Changes to make the PyTorch tests run

### DIFF
--- a/dietgpu/CMakeLists.txt
+++ b/dietgpu/CMakeLists.txt
@@ -9,6 +9,7 @@ add_dependencies(dietgpu
 target_link_libraries(dietgpu PRIVATE
   gpu_float_compress
   glog::glog
+  "${TORCH_LIBRARIES}"
 )
 target_include_directories(dietgpu PRIVATE
   $<BUILD_INTERFACE:${dietgpu_SOURCE_DIR}>

--- a/dietgpu/ans_test.py
+++ b/dietgpu/ans_test.py
@@ -7,7 +7,7 @@ import unittest
 
 import torch
 
-torch.ops.load_library("//dietgpu:dietgpu")
+torch.ops.load_library("../build/lib/libdietgpu.so")
 
 
 def run_test(dev, ts, temp_mem=None):

--- a/dietgpu/float_test.py
+++ b/dietgpu/float_test.py
@@ -7,7 +7,7 @@ import unittest
 
 import torch
 
-torch.ops.load_library("//dietgpu:dietgpu")
+torch.ops.load_library("../build/lib/libdietgpu.so")
 
 
 def run_test(dev, ts, temp_mem=None):


### PR DESCRIPTION
When I built the code and tried running the `float_test.py` it gave an error that the library file could not be found, so I changed the path to it's location in the build directory.  Then I was getting a `symbol not found` error because the library hadn't been linked to the PyTorch libraries.  I fixed that by adding a line to one of the CMakeLists.