### PR TITLE
dietgpu: add optional checksum and version number information

### DIFF
--- a/dietgpu/DietGpu.cpp
+++ b/dietgpu/DietGpu.cpp
@@ -150,6 +150,7 @@ std::tuple<torch::Tensor, torch::Tensor, int64_t> compress_data_res(
     bool compressAsFloat,
     StackDeviceMemory& res,
     const std::vector<torch::Tensor>& tIns,
+    bool checksum,
     const c10::optional<torch::Tensor>& outCompressed,
     const c10::optional<torch::Tensor>& outCompressedSizes) {
   TORCH_CHECK(!tIns.empty());
@@ -238,8 +239,9 @@ std::tuple<torch::Tensor, torch::Tensor, int64_t> compress_data_res(
   if (compressAsFloat) {
     auto config = FloatCompressConfig(
         getFloatTypeFromTensor(tIns[0]),
-        kDefaultPrecision,
-        false /* we'll figure this out later */);
+        ANSCodecConfig(kDefaultPrecision, false),
+        false /* we'll figure this out later */,
+        checksum);
 
     floatCompress(
         res,
@@ -252,9 +254,11 @@ std::tuple<torch::Tensor, torch::Tensor, int64_t> compress_data_res(
         (uint32_t*)sizes.data_ptr(),
         at::cuda::getCurrentCUDAStream());
   } else {
+    auto config = ANSCodecConfig(kDefaultPrecision, checksum);
+
     ansEncodeBatchPointer(
         res,
-        kDefaultPrecision,
+        config,
         tIns.size(),
         inPtrs.data(),
         inSize.data(),
@@ -273,6 +277,7 @@ std::tuple<torch::Tensor, torch::Tensor, int64_t> compress_data_res(
 std::tuple<torch::Tensor, torch::Tensor, int64_t> compress_data(
     bool compressAsFloat,
     const std::vector<torch::Tensor>& tIns,
+    bool checksum,
     const c10::optional<torch::Tensor>& tempMem,
     const c10::optional<torch::Tensor>& outCompressed,
     const c10::optional<torch::Tensor>& outCompressedSizes) {
@@ -299,7 +304,7 @@ std::tuple<torch::Tensor, torch::Tensor, int64_t> compress_data(
 
   // The rest of the validation takes place here
   return compress_data_res(
-      compressAsFloat, res, tIns, outCompressed, outCompressedSizes);
+      compressAsFloat, res, tIns, checksum, outCompressed, outCompressedSizes);
 }
 
 std::tuple<std::vector<torch::Tensor>, torch::Tensor, int64_t>
@@ -307,6 +312,7 @@ compress_data_split_size(
     bool compressAsFloat,
     const torch::Tensor& tIn,
     const torch::Tensor& tSplitSizes,
+    bool checksum,
     const c10::optional<torch::Tensor>& tempMem,
     const c10::optional<torch::Tensor>& outCompressed,
     const c10::optional<torch::Tensor>& outCompressedSizes) {
@@ -411,7 +417,10 @@ compress_data_split_size(
 
   if (compressAsFloat) {
     auto config = FloatCompressConfig(
-        floatType, kDefaultPrecision, false /* we'll figure this out later */);
+      floatType,
+      ANSCodecConfig(kDefaultPrecision, false),
+      false /* we'll figure this out later */,
+      checksum);
 
     floatCompressSplitSize(
         res,
@@ -426,9 +435,11 @@ compress_data_split_size(
         (uint32_t*)sizes.data_ptr(),
         stream);
   } else {
+    auto config = ANSCodecConfig(kDefaultPrecision, checksum);
+
     ansEncodeBatchSplitSize(
         res,
-        kDefaultPrecision,
+        config,
         numInBatch,
         tIn.data_ptr(),
         // FIXME: int32_t versus uint32_t
@@ -451,6 +462,7 @@ compress_data_split_size(
 std::vector<torch::Tensor> compress_data_simple(
     bool compressAsFloat,
     const std::vector<torch::Tensor>& tIns,
+    bool checksum,
     const c10::optional<int64_t>& tempMem) {
   TORCH_CHECK(!tIns.empty());
 
@@ -464,12 +476,12 @@ std::vector<torch::Tensor> compress_data_simple(
             .dtype(at::ScalarType::Byte));
 
     // rest of validation takes place here
-    comp =
-        compress_data(compressAsFloat, tIns, scratch, at::nullopt, at::nullopt);
+    comp = compress_data(
+        compressAsFloat, tIns, checksum, scratch, at::nullopt, at::nullopt);
   } else {
     // rest of validation takes place here
     comp = compress_data(
-        compressAsFloat, tIns, at::nullopt, at::nullopt, at::nullopt);
+        compressAsFloat, tIns, checksum, at::nullopt, at::nullopt, at::nullopt);
   }
 
   auto& compMatrix_dev = std::get<0>(comp);
@@ -514,6 +526,7 @@ int64_t decompress_data_res(
     StackDeviceMemory& res,
     const std::vector<torch::Tensor>& tIns,
     const std::vector<torch::Tensor>& tOuts,
+    bool checksum,
     const c10::optional<torch::Tensor>& outStatus,
     const c10::optional<torch::Tensor>& outSizes) {
   TORCH_CHECK(!tIns.empty());
@@ -579,8 +592,9 @@ int64_t decompress_data_res(
   if (compressAsFloat) {
     auto config = FloatDecompressConfig(
         getFloatTypeFromTensor(tOuts[0]),
-        kDefaultPrecision,
-        false /* we'll figure this out later */);
+        ANSCodecConfig(kDefaultPrecision, false),
+        false /* we'll figure this out later */,
+        checksum);
 
     floatDecompress(
         res,
@@ -594,9 +608,11 @@ int64_t decompress_data_res(
         outSizes ? (uint32_t*)outSizes->data_ptr() : nullptr,
         at::cuda::getCurrentCUDAStream());
   } else {
+    auto config = ANSCodecConfig(kDefaultPrecision, checksum);
+
     ansDecodeBatchPointer(
         res,
-        kDefaultPrecision,
+        config,
         tIns.size(),
         inPtrs.data(),
         outPtrs.data(),
@@ -615,6 +631,7 @@ int64_t decompress_data(
     bool compressAsFloat,
     const std::vector<torch::Tensor>& tIns,
     const std::vector<torch::Tensor>& tOuts,
+    bool checksum,
     const c10::optional<torch::Tensor>& tempMem,
     const c10::optional<torch::Tensor>& outStatus,
     const c10::optional<torch::Tensor>& outSizes) {
@@ -640,7 +657,7 @@ int64_t decompress_data(
 
   // Rest of validation happens here
   return decompress_data_res(
-      compressAsFloat, res, tIns, tOuts, outStatus, outSizes);
+     compressAsFloat, res, tIns, tOuts, checksum, outStatus, outSizes);
 }
 
 int64_t decompress_data_split_size(
@@ -648,6 +665,7 @@ int64_t decompress_data_split_size(
     const std::vector<torch::Tensor>& tIns,
     torch::Tensor& tOut,
     const torch::Tensor& tSplitSizes,
+    bool checksum,
     const c10::optional<torch::Tensor>& tempMem,
     const c10::optional<torch::Tensor>& outStatus,
     const c10::optional<torch::Tensor>& outSizes) {
@@ -739,8 +757,9 @@ int64_t decompress_data_split_size(
   if (compressAsFloat) {
     auto config = FloatDecompressConfig(
         getFloatTypeFromTensor(tOut),
-        kDefaultPrecision,
-        false /* we figure this out later */);
+        ANSCodecConfig(kDefaultPrecision, false),
+        false /* we figure this out later */,
+        checksum);
 
     floatDecompressSplitSize(
         res,
@@ -754,9 +773,11 @@ int64_t decompress_data_split_size(
         (uint32_t*)(outSizes ? outSizes->data_ptr() : nullptr),
         stream);
   } else {
+    auto config = ANSCodecConfig(kDefaultPrecision, checksum);
+
     ansDecodeBatchSplitSize(
         res,
-        kDefaultPrecision,
+        config,
         numInBatch,
         (const void**)inPtrs.data(),
         tOut.data_ptr(),
@@ -774,6 +795,7 @@ int64_t decompress_data_split_size(
 std::vector<torch::Tensor> decompress_data_simple(
     bool compressAsFloat,
     const std::vector<torch::Tensor>& tIns,
+    bool checksum,
     const c10::optional<int64_t>& tempMem) {
   TORCH_CHECK(!tIns.empty());
   auto stream = at::cuda::getCurrentCUDAStream();
@@ -856,7 +878,7 @@ std::vector<torch::Tensor> decompress_data_simple(
   }
 
   decompress_data_res(
-      compressAsFloat, res, tIns, tOuts, at::nullopt, at::nullopt);
+    compressAsFloat, res, tIns, tOuts, checksum, at::nullopt, at::nullopt);
 
   return tOuts;
 }
@@ -872,19 +894,19 @@ TORCH_LIBRARY_FRAGMENT(dietgpu, m) {
 
   // data compress
   m.def(
-      "compress_data(bool compress_as_float, Tensor[] ts_in, Tensor? temp_mem=None, Tensor? out_compressed=None, Tensor? out_compressed_bytes=None) -> (Tensor, Tensor, int)");
+      "compress_data(bool compress_as_float, Tensor[] ts_in, bool checksum=False, Tensor? temp_mem=None, Tensor? out_compressed=None, Tensor? out_compressed_bytes=None) -> (Tensor, Tensor, int)");
   m.def(
-      "compress_data_split_size(bool compress_as_float, Tensor t_in, Tensor t_in_split_sizes, Tensor? temp_mem=None, Tensor? out_compressed=None, Tensor? out_compressed_bytes=None) -> (Tensor[], Tensor, int)");
+      "compress_data_split_size(bool compress_as_float, Tensor t_in, Tensor t_in_split_sizes, bool checksum=False, Tensor? temp_mem=None, Tensor? out_compressed=None, Tensor? out_compressed_bytes=None) -> (Tensor[], Tensor, int)");
   m.def(
-      "compress_data_simple(bool compress_as_float, Tensor[] ts_in, int? temp_mem=67108864) -> Tensor[]");
+      "compress_data_simple(bool compress_as_float, Tensor[] ts_in, bool checksum=False, int? temp_mem=67108864) -> Tensor[]");
 
   // data decompress
   m.def(
-      "decompress_data(bool compress_as_float, Tensor[] ts_in, Tensor[] ts_out, Tensor? temp_mem=None, Tensor? out_status=None, Tensor? out_decompressed_words=None) -> (int)");
+      "decompress_data(bool compress_as_float, Tensor[] ts_in, Tensor[] ts_out, bool checksum=False, Tensor? temp_mem=None, Tensor? out_status=None, Tensor? out_decompressed_words=None) -> (int)");
   m.def(
-      "decompress_data_split_size(bool compress_as_float, Tensor[] ts_in, Tensor t_out, Tensor t_out_split_sizes, Tensor? temp_mem=None, Tensor? out_status=None, Tensor? out_decompressed_words=None) -> (int)");
+      "decompress_data_split_size(bool compress_as_float, Tensor[] ts_in, Tensor t_out, Tensor t_out_split_sizes, bool checksum=False, Tensor? temp_mem=None, Tensor? out_status=None, Tensor? out_decompressed_words=None) -> (int)");
   m.def(
-      "decompress_data_simple(bool compress_as_float, Tensor[] ts_in, int? temp_mem=67108864) -> Tensor[]");
+      "decompress_data_simple(bool compress_as_float, Tensor[] ts_in, bool checksum=False, int? temp_mem=67108864) -> Tensor[]");
 }
 
 TORCH_LIBRARY(dietgpu, m) {

--- a/dietgpu/ans/ANSTest.cu
+++ b/dietgpu/ans/ANSTest.cu
@@ -118,7 +118,7 @@ void runBatchPointer(
 
   ansEncodeBatchPointer(
       res,
-      prec,
+      ANSCodecConfig(prec, true),
       numInBatch,
       inPtrs.data(),
       batchSizes.data(),
@@ -144,11 +144,10 @@ void runBatchPointer(
 
   auto outSuccess_dev = res.alloc<uint8_t>(stream, numInBatch);
   auto outSize_dev = res.alloc<uint32_t>(stream, numInBatch);
-  ;
 
   ansDecodeBatchPointer(
       res,
-      prec,
+      ANSCodecConfig(prec, true),
       numInBatch,
       (const void**)encPtrs.data(),
       decPtrs.data(),
@@ -189,7 +188,7 @@ void runBatchStride(
 
   ansEncodeBatchStride(
       res,
-      ANSCodecConfig(prec),
+      ANSCodecConfig(prec, true),
       numInBatch,
       orig_dev.data(),
       inBatchSize,
@@ -215,7 +214,7 @@ void runBatchStride(
   // sure the compressed size is accurate
   ansDecodeBatchStride(
       res,
-      ANSCodecConfig(prec),
+      ANSCodecConfig(prec, true),
       numInBatch,
       enc_dev.data(),
       outBatchStride,

--- a/dietgpu/ans/GpuANSCodec.h
+++ b/dietgpu/ans/GpuANSCodec.h
@@ -22,15 +22,25 @@ constexpr int kANSDefaultProbBits = 10;
 uint32_t getMaxCompressedSize(uint32_t uncompressedBytes);
 
 struct ANSCodecConfig {
-  inline ANSCodecConfig() : probBits(kANSDefaultProbBits) {}
+  inline ANSCodecConfig() :
+      probBits(kANSDefaultProbBits), useChecksum(false) {}
 
-  inline ANSCodecConfig(int pb) : probBits(pb) {}
+  explicit inline ANSCodecConfig(int pb, bool checksum = false) :
+      probBits(pb), useChecksum(checksum) {}
 
   // What the ANS probability accuracy is; all symbols have quantized
   // probabilities of 1/2^probBits.
   // 9, 10, 11 are only valid values. When in doubt, use 10 (e.g., all symbol
   // probabilities are one of {1/1024, 2/1024, ..., 1023/1024, 1024/1024})
   int probBits;
+
+  // If true, we calculate a checksum on the uncompressed input data to
+  // compression and store it in the archive, and on the decompression side
+  // post-decompression, we calculate a checksum on the decompressed data which
+  // is compared with the original stored in the archive.
+  // This is an optional feature useful if DietGPU data will be stored
+  // persistently on disk.
+  bool useChecksum;
 };
 
 //

--- a/dietgpu/ans/GpuANSEncode.cuh
+++ b/dietgpu/ans/GpuANSEncode.cuh
@@ -9,6 +9,7 @@
 #include "dietgpu/ans/GpuANSCodec.h"
 #include "dietgpu/ans/GpuANSStatistics.cuh"
 #include "dietgpu/ans/GpuANSUtils.cuh"
+#include "dietgpu/ans/GpuChecksum.cuh"
 #include "dietgpu/utils/DeviceDefs.cuh"
 #include "dietgpu/utils/DeviceUtils.h"
 #include "dietgpu/utils/PtxUtils.cuh"
@@ -512,8 +513,10 @@ __device__ void ansEncodeCoalesce(
     uint32_t uncoalescedBlockStride,
     const uint32_t* __restrict__ compressedWords,
     const uint32_t* __restrict__ compressedWordsPrefix,
+    const uint32_t* __restrict__ checksum,
     const uint4* __restrict__ table,
     uint32_t probBits,
+    bool useChecksum,
     uint32_t numBlocks,
     uint32_t uncompressedWords,
     uint8_t* __restrict__ out,
@@ -543,10 +546,16 @@ __device__ void ansEncodeCoalesce(
       }
 
       ANSCoalescedHeader header;
+      header.setMagicAndVersion();
       header.setNumBlocks(numBlocks);
-      header.setUncompressedWords(uncompressedWords);
-      header.setCompressedWords(totalCompressedWords);
+      header.setTotalUncompressedWords(uncompressedWords);
+      header.setTotalCompressedWords(totalCompressedWords);
       header.setProbBits(probBits);
+      header.setUseChecksum(useChecksum);
+
+      if (useChecksum) {
+        header.setChecksum(*checksum);
+      }
 
       if (compressedBytes) {
         *compressedBytes = header.getTotalCompressedSize();
@@ -621,8 +630,10 @@ __global__ void ansEncodeCoalesceBatch(
     uint32_t uncoalescedBlockStride,
     const uint32_t* __restrict__ compressedWords,
     const uint32_t* __restrict__ compressedWordsPrefix,
+    const uint32_t* __restrict__ checksum,
     const uint4* __restrict__ table,
     uint32_t probBits,
+    bool useChecksum,
     OutProvider outProvider,
     uint32_t* __restrict__ compressedBytes) {
   int batch = blockIdx.y;
@@ -637,6 +648,7 @@ __global__ void ansEncodeCoalesceBatch(
   compressedWords += batch * maxNumCompressedBlocks;
   compressedWordsPrefix += batch * maxNumCompressedBlocks;
   compressedBytes += batch;
+  checksum += batch;
   table += batch * kNumSymbols;
 
   ansEncodeCoalesce<Threads>(
@@ -644,8 +656,10 @@ __global__ void ansEncodeCoalesceBatch(
       uncoalescedBlockStride,
       compressedWords,
       compressedWordsPrefix,
+      checksum,
       table,
       probBits,
+      useChecksum,
       numBlocks,
       uncompressedWords,
       (uint8_t*)outProvider.getBatchStart(batch),
@@ -695,7 +709,13 @@ void ansEncodeBatchDevice(
         stream);
   }
 
-  // 2. Allocate memory for the per-warp results
+  // 2. Compute checksum on input data (optional)
+  auto checksum_dev = res.alloc<uint32_t>(stream, numInBatch);
+  if (config.useChecksum) {
+    checksumBatch(numInBatch, inProvider, checksum_dev.data(), stream);
+  }
+
+  // 3. Allocate memory for the per-warp results
   // How much space in bytes we need to reserve for each warp's output
   uint32_t uncoalescedBlockStride =
       getMaxBlockSizeUnCoalesced(kDefaultBlockSize);
@@ -812,8 +832,10 @@ void ansEncodeBatchDevice(
             uncoalescedBlockStride,
             compressedWords_dev.data(),
             compressedWordsPrefix_dev.data(),
+            checksum_dev.data(),
             table_dev.data(),
             config.probBits,
+            config.useChecksum,
             outProvider,
             outSize_dev);
   }

--- a/dietgpu/ans/GpuANSInfo.cu
+++ b/dietgpu/ans/GpuANSInfo.cu
@@ -19,8 +19,8 @@ ansGetCompressedInfo(const void** in, uint32_t numInBatch, uint32_t* outSizes) {
   if (idx < numInBatch) {
     auto header = *(ANSCoalescedHeader*)in[idx];
 
-    header.checkMagic();
-    outSizes[idx] = header.totalUncompressedWords();
+    header.checkMagicAndVersion();
+    outSizes[idx] = header.getTotalUncompressedWords();
   }
 }
 

--- a/dietgpu/ans/GpuANSUtils.cuh
+++ b/dietgpu/ans/GpuANSUtils.cuh
@@ -48,7 +48,11 @@ constexpr ANSStateT kANSStartState = ANSStateT(1)
 constexpr ANSStateT kANSMinState = ANSStateT(1)
     << (kANSStateBits - kANSEncodedBits);
 
-constexpr uint32_t kCoalescedHeaderMagic = 0xa5;
+// magic number to verify archive integrity
+constexpr uint32_t kANSMagic = 0xd00d;
+
+// current DietGPU version number
+constexpr uint32_t kANSVersion = 0x0001;
 
 // Each block of compressed data (either coalesced or uncoalesced) is aligned to
 // this number of bytes and has a valid (if not all used) segment with this
@@ -60,7 +64,7 @@ struct ANSWarpState {
   ANSStateT warpState[kWarpSize];
 };
 
-struct __align__(16) ANSCoalescedHeader {
+struct __align__(32) ANSCoalescedHeader {
   static __host__ __device__ uint32_t getCompressedOverhead(
       uint32_t numBlocks) {
     constexpr int kAlignment = kBlockAlignment / sizeof(uint2) == 0
@@ -78,53 +82,74 @@ struct __align__(16) ANSCoalescedHeader {
 
   __host__ __device__ uint32_t getTotalCompressedSize() const {
     return getCompressedOverhead() +
-        totalCompressedWords() * sizeof(ANSEncodedT);
+        getTotalCompressedWords() * sizeof(ANSEncodedT);
   }
 
   __host__ __device__ uint32_t getCompressedOverhead() const {
-    return getCompressedOverhead(numBlocks());
+    return getCompressedOverhead(getNumBlocks());
   }
 
   __host__ __device__ float getCompressionRatio() const {
-    return (float)getTotalCompressedSize() / (float)totalUncompressedWords() *
+    return (float)getTotalCompressedSize() / (float)getTotalUncompressedWords() *
         sizeof(ANSDecodedT);
   }
 
-  __host__ __device__ uint32_t numBlocks() const {
-    return (data0.x & 0xffffffU);
+  __host__ __device__ uint32_t getNumBlocks() const {
+    return numBlocks;
   }
 
-  __host__ __device__ void setNumBlocks(uint32_t numBlocks) {
-    assert(numBlocks <= 0xffffffU);
-    data0.x = (kCoalescedHeaderMagic << 24) | numBlocks;
+  __host__ __device__ void setNumBlocks(uint32_t nb) {
+    numBlocks = nb;
   }
 
-  __host__ __device__ void checkMagic() const {
-    assert((data0.x >> 24) == kCoalescedHeaderMagic);
+  __host__ __device__ void setMagicAndVersion() {
+    magicAndVersion = (kANSMagic << 16) | kANSVersion;
   }
 
-  __host__ __device__ uint32_t totalUncompressedWords() const {
-    return data0.y;
+  __host__ __device__ void checkMagicAndVersion() const {
+    assert((magicAndVersion >> 16) == kANSMagic);
+    assert((magicAndVersion & 0xffffU) == kANSVersion);
   }
 
-  __host__ __device__ void setUncompressedWords(uint32_t words) {
-    data0.y = words;
+  __host__ __device__ uint32_t getTotalUncompressedWords() const {
+    return totalUncompressedWords;
   }
 
-  __host__ __device__ uint32_t totalCompressedWords() const {
-    return data0.z;
+  __host__ __device__ void setTotalUncompressedWords(uint32_t words) {
+    totalUncompressedWords = words;
   }
 
-  __host__ __device__ void setCompressedWords(uint32_t words) {
-    data0.z = words;
+  __host__ __device__ uint32_t getTotalCompressedWords() const {
+    return totalCompressedWords;
   }
 
-  __host__ __device__ uint32_t probBits() const {
-    return data0.w;
+  __host__ __device__ void setTotalCompressedWords(uint32_t words) {
+    totalCompressedWords = words;
+  }
+
+  __host__ __device__ uint32_t getProbBits() const {
+    return options & 0xf;
   }
 
   __host__ __device__ void setProbBits(uint32_t bits) {
-    data0.w = bits;
+    assert(bits <= 0xf);
+    options = (options & 0xfffffff0U) | bits;
+  }
+
+  __host__ __device__ bool getUseChecksum() const {
+    return options & 0x10;
+  }
+
+  __host__ __device__ void setUseChecksum(bool uc) {
+    options = (options & 0xffffffef) | (uint32_t(uc) << 4);
+  }
+
+  __host__ __device__ uint32_t getChecksum() const {
+    return checksum;
+  }
+
+  __host__ __device__ void setChecksum(uint32_t c) {
+    checksum = c;
   }
 
   __device__ uint16_t* getSymbolProbs() {
@@ -171,11 +196,19 @@ struct __align__(16) ANSCoalescedHeader {
         const ANSEncodedT*)(getBlockWords(numBlocks) + roundUp(numBlocks, kAlignment));
   }
 
-  // x: (8: magic)(24: numBlocks)
-  // y: totalUncompressedWords
-  // z: totalCompressedWords
-  // w: probBits
-  uint4 data0;
+  // (16: magic)(16: version)
+  uint32_t magicAndVersion;
+  uint32_t numBlocks;
+  uint32_t totalUncompressedWords;
+  uint32_t totalCompressedWords;
+
+  // (27: unused)(1: use checksum)(4: probBits)
+  uint32_t options;
+  uint32_t checksum;
+  uint32_t unused0;
+  uint32_t unused1;
+
+  // Data that follows after the header (some of which is variable length):
 
   // Fixed length array
   // uint16_t probs[kNumSymbols];
@@ -189,7 +222,11 @@ struct __align__(16) ANSCoalescedHeader {
   //
   // Variable length array:
   // uint2 blockWords[roundUp(numBlocks, kBlockAlignment / sizeof(uint2))];
+
+  // Then follows the compressed per-warp/block data for each segment
 };
+
+static_assert(sizeof(ANSCoalescedHeader) == 32, "");
 
 static_assert(isEvenDivisor(sizeof(ANSCoalescedHeader), sizeof(uint4)), "");
 

--- a/dietgpu/ans/GpuChecksum.cuh
+++ b/dietgpu/ans/GpuChecksum.cuh
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include "dietgpu/utils/DeviceDefs.cuh"
+#include "dietgpu/utils/DeviceUtils.h"
+#include "dietgpu/utils/PtxUtils.cuh"
+#include "dietgpu/utils/StaticUtils.h"
+
+#include <cub/cub.cuh>
+
+namespace dietgpu {
+
+template <typename T>
+struct ReduceXor {
+  __host__ __device__ __forceinline__
+  T operator()(const T& a, const T& b) const {
+    return a ^ b;
+  }
+};
+
+template <int Threads>
+__device__ void checksumSingle(
+    const uint8_t* __restrict__ in,
+    uint32_t size,
+    uint32_t* __restrict__ out) {
+  // FIXME: general presumption in dietgpu that input data for ANS is only byte
+  // aligned, while float data is only float word aligned, whereas ideally we
+  // would like a 32 bit checksum. Since there is ultimately no guarantee of
+  // anything but byte alignment and we wish to compute the same checksum
+  // regardless of memory placement, the only checksum that makes sense to
+  // produce is uint8.
+  // We can fix this to compute a full 32-bit checksum by keeping track of
+  // initial alignment and shuffling data around I think.
+  uint32_t checksum32 = 0;
+
+  // If the size of batch is smaller than the increment for alignment, we only
+  // handle the batch
+  auto roundUp4 = min(size, getAlignmentRoundUp<sizeof(uint4)>(in));
+
+  // The size of data that remains after alignment
+  auto remaining = size - roundUp4;
+
+  // The size of data (in uint4 words) that we can process with alignment
+  uint32_t numU4 = divDown(remaining, sizeof(uint4));
+
+  auto inAligned = in + roundUp4;
+  auto inAligned4 = (const uint4*)inAligned;
+
+  // Handle the non-aligned portion that we have to load as single bytes, if any
+  if (blockIdx.x == 0 && threadIdx.x < roundUp4) {
+    static_assert(sizeof(uint4) <= Threads, "");
+    checksum32 ^= in[threadIdx.x];
+  }
+
+  // Handle the portion that is aligned and uint4 vectorizable
+  // 37.60 us / 80.76% gmem / 51.29% smem for uint4 on A100
+  for (uint32_t i = blockIdx.x * Threads + threadIdx.x; i < numU4;
+       i += gridDim.x * Threads) {
+    uint4 v = inAligned4[i];
+
+    checksum32 ^= v.x;
+    checksum32 ^= v.y;
+    checksum32 ^= v.z;
+    checksum32 ^= v.w;
+  }
+
+  if (blockIdx.x == 0) {
+    // Handle the remainder portion that doesn't comprise full words
+    int i = numU4 * sizeof(uint4) + threadIdx.x;
+    if (i < remaining) {
+      checksum32 ^= inAligned[i];
+    }
+  }
+
+  // Fold the bytes of checksum32
+  checksum32 = (checksum32 & 0xffU) ^
+    ((checksum32 >> 8) & 0xffU) ^
+    ((checksum32 >> 16) & 0xffU) ^
+    ((checksum32 >> 24) & 0xffU);
+
+  // Reduce within a warp
+  using BlockReduce = cub::BlockReduce<uint32_t, Threads>;
+  __shared__ typename BlockReduce::TempStorage smem;
+
+  checksum32 = BlockReduce(smem).Reduce(checksum32, ReduceXor<uint32_t>());
+
+  if (threadIdx.x == 0) {
+    atomicXor(out, checksum32);
+  }
+}
+
+template <typename InProvider, int Threads>
+__global__ void checksumBatch(InProvider in, uint32_t* out) {
+  int batch = blockIdx.y;
+  out += batch;
+
+  checksumSingle<Threads>(
+      (const uint8_t*)in.getBatchStart(batch), in.getBatchSize(batch), out);
+}
+
+template <typename InProvider>
+void checksumBatch(
+    uint32_t numInBatch,
+    InProvider inProvider,
+    // size numInBatch
+    uint32_t* checksum_dev,
+    cudaStream_t stream) {
+  // zero out checksum before proceeding, as we aggregate with atomic xor
+  CUDA_VERIFY(cudaMemsetAsync(
+      checksum_dev, 0, sizeof(uint32_t) * numInBatch, stream));
+
+  {
+    constexpr uint32_t kThreads = 256;
+
+    // We unfortunately don't know the per-batch element sizes in advance
+    // What is the maximum number of blocks to saturate the GPU?
+    int maxBlocks = 0;
+    CUDA_VERIFY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+       &maxBlocks, checksumBatch<InProvider, kThreads>, kThreads, 0));
+    maxBlocks *= getCurrentDeviceProperties().multiProcessorCount;
+
+    // The y block dimension will be for each batch element
+    uint32_t xBlocks = divUp(maxBlocks, numInBatch);
+    auto grid = dim3(xBlocks, numInBatch);
+
+    checksumBatch<InProvider, kThreads>
+        <<<grid, kThreads, 0, stream>>>(inProvider, checksum_dev);
+  }
+}
+
+} // namespace dietgpu

--- a/dietgpu/ans_test.py
+++ b/dietgpu/ans_test.py
@@ -10,8 +10,8 @@ import torch
 torch.ops.load_library("//dietgpu:dietgpu")
 
 
-def run_test(dev, ts, temp_mem=None):
-    comp, sizes, _ = torch.ops.dietgpu.compress_data(False, ts, temp_mem)
+def run_test(dev, ts, checksum, temp_mem=None):
+    comp, sizes, _ = torch.ops.dietgpu.compress_data(False, ts, checksum, temp_mem)
     for s, t in zip(sizes, ts):
         t_bytes = t.numel() * t.element_size()
         print(
@@ -34,14 +34,14 @@ def run_test(dev, ts, temp_mem=None):
         out_sizes = torch.empty([len(ts)], dtype=torch.int32, device=dev)
 
         torch.ops.dietgpu.decompress_data(
-            False, truncated_comp, out_ts, temp_mem, out_status, out_sizes
+            False, truncated_comp, out_ts, checksum, temp_mem, out_status, out_sizes
         )
 
         for t, status, size in zip(ts, out_status, out_sizes):
             assert status.item()
             assert t.numel() * t.element_size() == size.item()
     else:
-        torch.ops.dietgpu.decompress_data(False, truncated_comp, out_ts)
+        torch.ops.dietgpu.decompress_data(False, truncated_comp, out_ts, checksum)
 
     for a, b in zip(ts, out_ts):
         assert torch.equal(a, b)
@@ -54,25 +54,26 @@ class TestANSCodec(unittest.TestCase):
 
         for dt in [torch.float32]:
             for tm in [False, True]:
-                ts = [
-                    torch.normal(0, 1.0, [10000], dtype=dt, device=dev),
-                    torch.normal(0, 1.0, [100000], dtype=dt, device=dev),
-                    torch.normal(0, 1.0, [1000000], dtype=dt, device=dev),
-                ]
-                if tm:
-                    run_test(dev, ts, temp_mem)
-                else:
-                    run_test(dev, ts)
+                for checksum in [False, True]:
+                    ts = [
+                        torch.normal(0, 1.0, [10000], dtype=dt, device=dev),
+                        torch.normal(0, 1.0, [100000], dtype=dt, device=dev),
+                        torch.normal(0, 1.0, [1000000], dtype=dt, device=dev),
+                    ]
+                    if tm:
+                        run_test(dev, ts, checksum, temp_mem)
+                    else:
+                        run_test(dev, ts, checksum)
 
     def test_empty(self):
         dev = torch.device("cuda:0")
         ts = [torch.empty([0], dtype=torch.uint8, device=dev)]
-        comp_ts = torch.ops.dietgpu.compress_data_simple(False, ts)
+        comp_ts = torch.ops.dietgpu.compress_data_simple(False, ts, True)
 
         # should have a header
         assert comp_ts[0].numel() > 0
 
-        decomp_ts = torch.ops.dietgpu.decompress_data_simple(False, comp_ts)
+        decomp_ts = torch.ops.dietgpu.decompress_data_simple(False, comp_ts, True)
         assert torch.equal(ts[0], decomp_ts[0])
 
     def test_split_compress(self):
@@ -100,9 +101,9 @@ class TestANSCodec(unittest.TestCase):
             splits = torch.split(t, sizes)
 
             comp_ts, _, _ = torch.ops.dietgpu.compress_data_split_size(
-                False, t, sizes_t, temp_mem
+                False, t, sizes_t, True, temp_mem
             )
-            decomp_ts = torch.ops.dietgpu.decompress_data_simple(False, comp_ts)
+            decomp_ts = torch.ops.dietgpu.decompress_data_simple(False, comp_ts, True)
 
             for orig, decomp in zip(splits, decomp_ts):
                 assert torch.equal(orig, decomp)
@@ -128,11 +129,11 @@ class TestANSCodec(unittest.TestCase):
             sizes_t = torch.IntTensor(sizes)
 
             splits = torch.split(t, sizes)
-            comp_ts = torch.ops.dietgpu.compress_data_simple(False, splits)
+            comp_ts = torch.ops.dietgpu.compress_data_simple(False, splits, True)
 
             decomp_t = torch.empty([sum_sizes], dtype=torch.uint8, device=dev)
             torch.ops.dietgpu.decompress_data_split_size(
-                False, comp_ts, decomp_t, sizes_t, temp_mem
+                False, comp_ts, decomp_t, sizes_t, True, temp_mem
             )
 
             assert torch.equal(t, decomp_t)

--- a/dietgpu/float/FloatTest.cu
+++ b/dietgpu/float/FloatTest.cu
@@ -162,7 +162,8 @@ void runBatchPointerTest(
 
   auto outBatchSize_dev = res.alloc<uint32_t>(stream, numInBatch);
 
-  auto compConfig = FloatCompressConfig(FT, probBits, false);
+  auto compConfig =
+    FloatCompressConfig(FT, ANSCodecConfig(probBits), false, true);
 
   floatCompress(
       res,
@@ -189,7 +190,8 @@ void runBatchPointerTest(
   auto outSuccess_dev = res.alloc<uint8_t>(stream, numInBatch);
   auto outSize_dev = res.alloc<uint32_t>(stream, numInBatch);
 
-  auto decompConfig = FloatDecompressConfig(FT, probBits, false);
+  auto decompConfig =
+    FloatDecompressConfig(FT, ANSCodecConfig(probBits), false, true);
 
   floatDecompress(
       res,

--- a/dietgpu/float/GpuFloatCodec.h
+++ b/dietgpu/float/GpuFloatCodec.h
@@ -15,7 +15,7 @@ namespace dietgpu {
 class StackDeviceMemory;
 
 // The various floating point types we support for compression
-enum FloatType {
+enum FloatType : uint32_t {
   kUndefined = 0,
   kFloat16 = 1,
   kBFloat16 = 2,
@@ -32,18 +32,39 @@ uint32_t getMaxFloatCompressedSize(FloatType floatType, uint32_t size);
 
 struct FloatCodecConfig {
   inline FloatCodecConfig()
-      : floatType(FloatType::kFloat16), is16ByteAligned(false) {}
+      : floatType(FloatType::kFloat16),
+        useChecksum(false),
+        is16ByteAligned(false) {}
 
   inline FloatCodecConfig(
       FloatType ft,
       const ANSCodecConfig& ansConf,
-      bool align)
-      : floatType(ft), ansConfig(ansConf), is16ByteAligned(align) {}
+      bool align,
+      bool checksum = false)
+      : floatType(ft),
+        useChecksum(checksum),
+        ansConfig(ansConf),
+        is16ByteAligned(align) {
+    // ANS-level checksumming is not allowed in float mode, only float level
+    // checksumming
+    assert(!ansConf.useChecksum);
+  }
 
   // What kind of floats are we compressing/decompressing?
   FloatType floatType;
 
+  // If true, we calculate a checksum on the uncompressed float input data to
+  // compression and store it in the archive, and on the decompression side
+  // post-decompression, we calculate a checksum on the decompressed data which
+  // is compared with the original stored in the archive.
+  // This is an optional feature useful if DietGPU data will be stored
+  // persistently on disk.
+  bool useChecksum;
+
   // ANS entropy coder parameters
+  // Checksumming will happen at the float level, not the ANS level, as
+  // decompression from ANS is immediately consumed by the float layer,
+  // so ansConfig.useChecksum being true is an error.
   ANSCodecConfig ansConfig;
 
   // Are all all float input pointers/offsets (compress) or output

--- a/dietgpu/float/GpuFloatCompress.cuh
+++ b/dietgpu/float/GpuFloatCompress.cuh
@@ -8,6 +8,7 @@
 #include "dietgpu/ans/BatchProvider.cuh"
 #include "dietgpu/ans/GpuANSEncode.cuh"
 #include "dietgpu/ans/GpuANSUtils.cuh"
+#include "dietgpu/ans/GpuChecksum.cuh"
 #include "dietgpu/float/GpuFloatCodec.h"
 #include "dietgpu/float/GpuFloatUtils.cuh"
 #include "dietgpu/utils/DeviceDefs.cuh"
@@ -283,6 +284,8 @@ template <
     int Threads>
 __global__ void splitFloat(
     InProvider inProvider,
+    bool useChecksum,
+    const uint32_t* __restrict__ checksum,
     void* __restrict__ compOut,
     uint32_t compOutStride,
     NonCompProvider nonCompProvider,
@@ -298,6 +301,7 @@ __global__ void splitFloat(
   int warpId = threadIdx.x / kWarpSize;
 
   histogramOut += batch * kNumSymbols;
+  checksum += batch;
 
   // +1 in order to force very common symbols that could overlap into different
   // banks between different warps
@@ -320,9 +324,15 @@ __global__ void splitFloat(
   // Write size as a header
   if (blockIdx.x == 0 && threadIdx.x == 0) {
     GpuFloatHeader h;
-    h.magic = kGpuFloatHeaderMagic;
+    h.setMagicAndVersion();
     h.size = curSize;
-    h.floatType = FT;
+    h.setFloatType(FT);
+    h.setUseChecksum(useChecksum);
+
+    if (useChecksum) {
+      h.setChecksum(*checksum);
+    }
+
     *headerOut = h;
   }
 
@@ -411,7 +421,7 @@ struct FloatANSOutProvider {
     uint8_t* p = (uint8_t*)outProvider_.getBatchStart(batch);
 
     // Increment the pointer to past the floating point data
-    assert(((GpuFloatHeader*)p)->magic == kGpuFloatHeaderMagic);
+    ((GpuFloatHeader*)p)->checkMagicAndVersion();
     return p + sizeof(GpuFloatHeader) +
         FTI::getUncompDataSize(sizeProvider_.getBatchSize(batch));
   }
@@ -420,7 +430,7 @@ struct FloatANSOutProvider {
     const uint8_t* p = (const uint8_t*)outProvider_.getBatchStart(batch);
 
     // Increment the pointer to past the floating point data
-    assert(((GpuFloatHeader*)p)->magic == kGpuFloatHeaderMagic);
+    ((GpuFloatHeader*)p)->checkMagicAndVersion();
     return p + sizeof(GpuFloatHeader) +
         FTI::getUncompDataSize(sizeProvider_.getBatchSize(batch));
   }
@@ -446,6 +456,16 @@ void floatCompressDevice(
   auto maxUncompressedWords = maxSize / sizeof(ANSDecodedT);
   uint32_t maxNumCompressedBlocks =
       divUp(maxUncompressedWords, kDefaultBlockSize);
+
+  // Compute checksum on input data (optional)
+  auto checksum_dev = res.alloc<uint32_t>(stream, numInBatch);
+
+  // not allowed in float mode
+  assert(!config.ansConfig.useChecksum);
+
+  if (config.useChecksum) {
+    checksumBatch(numInBatch, inProvider, checksum_dev.data(), stream);
+  }
 
   // Temporary space for the extracted exponents; all rows must be 16 byte
   // aligned
@@ -480,6 +500,8 @@ void floatCompressDevice(
     splitFloat<InProvider, OutProvider, FLOAT_TYPE, kBlock>        \
         <<<grid, kBlock, 0, stream>>>(                             \
             inProvider,                                            \
+            config.useChecksum,                                    \
+            checksum_dev.data(),                                   \
             toComp_dev.data(),                                     \
             compRowStride,                                         \
             outProvider,                                           \

--- a/dietgpu/float/GpuFloatInfo.cu
+++ b/dietgpu/float/GpuFloatInfo.cu
@@ -22,13 +22,13 @@ __global__ void floatGetCompressedInfo(
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < numInBatch) {
     auto header = *(GpuFloatHeader*)in[idx];
+    header.checkMagicAndVersion();
 
     uint32_t size = 0;
     uint32_t type = FloatType::kUndefined;
 
-    assert(header.magic == kGpuFloatHeaderMagic);
     size = header.size;
-    type = header.floatType;
+    type = header.getFloatType();
 
     if (outSizes) {
       outSizes[idx] = size;

--- a/dietgpu/float_test.py
+++ b/dietgpu/float_test.py
@@ -11,7 +11,7 @@ torch.ops.load_library("//dietgpu:dietgpu")
 
 
 def run_test(dev, ts, temp_mem=None):
-    comp, sizes, _ = torch.ops.dietgpu.compress_data(True, ts, temp_mem)
+    comp, sizes, _ = torch.ops.dietgpu.compress_data(True, ts, True, temp_mem)
     for s, t in zip(sizes, ts):
         t_bytes = t.numel() * t.element_size()
         print(
@@ -34,14 +34,14 @@ def run_test(dev, ts, temp_mem=None):
         out_sizes = torch.empty([len(ts)], dtype=torch.int32, device=dev)
 
         torch.ops.dietgpu.decompress_data(
-            True, truncated_comp, out_ts, temp_mem, out_status, out_sizes
+            True, truncated_comp, out_ts, True, temp_mem, out_status, out_sizes
         )
 
         for t, status, size in zip(ts, out_status, out_sizes):
             assert status.item()
             assert t.numel() == size.item()
     else:
-        torch.ops.dietgpu.decompress_data(True, truncated_comp, out_ts)
+        torch.ops.dietgpu.decompress_data(True, truncated_comp, out_ts, True)
 
     for a, b in zip(ts, out_ts):
         assert torch.equal(a, b)
@@ -83,7 +83,7 @@ class TestFloatCodec(unittest.TestCase):
                 for i in [10000, 100000, 1000000]
             ]
 
-            cts = torch.ops.dietgpu.compress_data_simple(True, ts)
+            cts = torch.ops.dietgpu.compress_data_simple(True, ts, True)
             for before, after in zip(ts, cts):
                 # We should actually be compressing data
                 assert (
@@ -91,7 +91,7 @@ class TestFloatCodec(unittest.TestCase):
                     > after.numel() * after.element_size()
                 )
 
-            dts = torch.ops.dietgpu.decompress_data_simple(True, cts)
+            dts = torch.ops.dietgpu.decompress_data_simple(True, cts, True)
             for orig, after in zip(ts, dts):
                 assert torch.equal(orig, after)
 
@@ -99,12 +99,12 @@ class TestFloatCodec(unittest.TestCase):
         dev = torch.device("cuda:0")
         for dt in [torch.bfloat16, torch.float16, torch.float32]:
             ts = [torch.empty([0], dtype=dt, device=dev)]
-            comp_ts = torch.ops.dietgpu.compress_data_simple(True, ts)
+            comp_ts = torch.ops.dietgpu.compress_data_simple(True, ts, True)
 
             # should have a header
             assert comp_ts[0].numel() > 0
 
-            decomp_ts = torch.ops.dietgpu.decompress_data_simple(True, comp_ts)
+            decomp_ts = torch.ops.dietgpu.decompress_data_simple(True, comp_ts, True)
             assert torch.equal(ts[0], decomp_ts[0])
 
     def test_split_compress(self):
@@ -135,9 +135,9 @@ class TestFloatCodec(unittest.TestCase):
                     splits = torch.split(t, sizes)
 
                     comp_ts, _, _ = torch.ops.dietgpu.compress_data_split_size(
-                        True, t, sizes_t, temp_mem
+                        True, t, sizes_t, True, temp_mem
                     )
-                    decomp_ts = torch.ops.dietgpu.decompress_data_simple(True, comp_ts)
+                    decomp_ts = torch.ops.dietgpu.decompress_data_simple(True, comp_ts, True)
 
                     for orig, decomp in zip(splits, decomp_ts):
                         assert torch.equal(orig, decomp)
@@ -166,11 +166,11 @@ class TestFloatCodec(unittest.TestCase):
                     sizes_t = torch.IntTensor(sizes)
 
                     splits = torch.split(t, sizes)
-                    comp_ts = torch.ops.dietgpu.compress_data_simple(True, splits)
+                    comp_ts = torch.ops.dietgpu.compress_data_simple(True, splits, True)
 
                     decomp_t = torch.empty([sum_sizes], dtype=dt, device=dev)
                     torch.ops.dietgpu.decompress_data_split_size(
-                        True, comp_ts, decomp_t, sizes_t, temp_mem
+                        True, comp_ts, decomp_t, sizes_t, True, temp_mem
                     )
 
                     assert torch.equal(t, decomp_t)


### PR DESCRIPTION
Summary:
This diff adds two useful features for using DietGPU to store numeric data in persistent storage (e.g., for checkpointing large language model training purposes).

**1** This diff adds an optional feature to calculate a checksum of the data to be compressed which is stored in the archive, as well as an option to check the stored checksum against the decompressed data post-decompression. This is an additional check to safeguard the archival integrity of DietGPU.

All compress/decompress functions add an additional optional parameter to enable the checksum feature, which is the first optional parameter for all the functions.

There are two checksum flags, one for byte-wise ANS and one for the float compression. With float compression, the ANS flag cannot be used.

Computing and comparing the checksum adds another full pass to the data, so it is not recommended to use it for online, in-memory compression/decompression (e.g., shipping data over a network).

**2** A version number has been added to both the ANS and float data headers inside the archive. This will be used to safeguard against data format changes in subsequent iterations of DietGPU, in order to detect when a newer (or older) version of the library is being used to unpack an older (or newer, respectively) versioned archive.

Either failure (checksum mismatch or version mismatch) will cause a fatal assert within the CUDA kernels that check for this.

Also added a missing check that the float type in the archive expected upon decompression matches what is stored in the archive.

In order to add this feature, the data layout of the DietGPU archive has changed to include space for the checksum in the headers.

Issues / to do:
- the checksum at present is only 8 bits due to a (lack of) data alignment expectation, and is just a simple xor reduction at present. The ANS compressor can accept any input regardless of alignment (only byte alignment is required), while the float compressor expects float word-sized alignment (e.g., float16 requires 2 byte alignment). The checksum kernel ideally should compute a full uint32 checksum (if xor), or just use something like crc32. This is a todo.
- asserts will be compiled out if `NDEBUG` is defined. The assert needs to be replaced with a d2h copy of the error status and raising an error on the host side instead.

Differential Revision: D41829599

