### PR TITLE
Always build the targets under fbcode//ai_codesign/comms/compression: using H100a and CUDA 12.8

### DIFF
--- a/dietgpu/ans/GpuANSEncode.cuh
+++ b/dietgpu/ans/GpuANSEncode.cuh
@@ -499,8 +499,12 @@ struct Align {
   typedef uint32_t argument_type;
   typedef uint32_t result_type;
 
-  __thrust_exec_check_disable__ template <typename T>
-  __host__ __device__ uint32_t operator()(T x) const {
+#if (__CUDACC_VER_MAJOR__ < 12) || \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ < 8)
+  __thrust_exec_check_disable__
+#endif
+      template <typename T>
+      __host__ __device__ uint32_t operator()(T x) const {
     constexpr int kDiv = B / sizeof(A);
     constexpr int kSize = kDiv < 1 ? 1 : kDiv;
 


### PR DESCRIPTION
Summary:
```
$ buck2 build fbcode//ai_codesign/comms/compression:compression_manager_async_example
BUILD FAILED
Error running analysis for `fbcode//ai_codesign/comms/compression:compression_manager_async_example (cfg:dev-linux-x86_64-fbcode-platform010-clang19-asan-ubsan-dev#29c8dc642832b616)`

Caused by:
    0: Error in configured node dependency, dependency chain follows (-> indicates depends on, ^ indicates same configuration as previous):
              fbcode//ai_codesign/comms/compression:compression_manager_async_example (cfg:dev-linux-x86_64-fbcode-platform010-clang19-asan-ubsan-dev#29c8dc642832b616)
           -> fbcode//ai_codesign/comms/compression:compression_manager_async_example_linked (^)
           -> fbcode//ai_codesign/comms/compression:compression_manager_async_example_dlink (^)
           -> fbcode//third-party-buck/platform010/build/cuda:cudadevrt (^)

    1: configuring attr `actual`
    2: None of 3 conditions matched configuration `cfg:dev-linux-x86_64-fbcode-platform010-clang19-asan-ubsan-dev#29c8dc642832b616` and no default was set:
         ovr_config//third-party/cuda/constraints:12.8
         ovr_config//third-party/cuda/constraints:13.0
         ovr_config//third-party/cuda/constraints:latest
```

this error is because The CUDA version in fbcode/ai_codesign/PACKAGE is 12.4, and in its child package fbcode/ai_codesign/comms/PACKAGE, they did not explicitly specify CUDA version, so it just inherits the default CUDA version 12.4. Therefore, all the targets in fbcode/ai_codesign/comms/compression/BUCK will be built with CUDA 12.4.

Confirmed with rashidi1saeed, we specify cuda 12.8 and nvcc arch h100a in its package files

Removing __thrust_exec_check_disable__ because fbcode//dietgpu/ans:gpu_ans is based on CUDA 12.4, and thrust_exec_check_disable does not appear to be present in CUDA 12.8 or newer (https://fburl.com/code/chu3nhdl). So when you compile with cuda 12.8, it will fail.

Differential Revision: D85169241


