### PR TITLE
Fix build on CUDA 12.6 and Pytorch >= 2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,14 @@
 
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(dietgpu LANGUAGES CUDA CXX VERSION 1.0)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 11)
 
 include(CheckLanguage)
 check_language(CUDA)
 
 if(NOT DEFINED CMAKE_CUDA_STANDARD)
-    set(CMAKE_CUDA_STANDARD 14)
+    set(CMAKE_CUDA_STANDARD 17)
     set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 endif()
 

--- a/dietgpu/ans/GpuANSEncode.cuh
+++ b/dietgpu/ans/GpuANSEncode.cuh
@@ -499,8 +499,9 @@ struct Align {
   typedef uint32_t argument_type;
   typedef uint32_t result_type;
 
-#if (__CUDACC_VER_MAJOR__ < 12) || \
-    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ < 8)
+#if defined(_CCCL_EXEC_CHECK_DISABLE)
+  _CCCL_EXEC_CHECK_DISABLE
+#elif defined(__thrust_exec_check_disable__)
   __thrust_exec_check_disable__
 #endif
       template <typename T>


### PR DESCRIPTION
This PR is a re-submission of #22 

## The issue of `__thrust_exec_check_disable__` macro
On my environment with CUDA 12.6, build is still broken after the change e1ea8bd917407afdc3463740cd10985c72709d02 .

Although I'm not sure about when `__thrust_exec_check_disable__` was removed, but 
I checked the NVIDIA's official Docker image and confirmed that it was already removed at 12.6.

```
$ docker run -it nvidia/cuda:12.6.3-cudnn-devel-ubuntu20.04 -- bash -c "grep '__thrust_exec_check_disable__' -r /usr/local/cuda/*/*/include"

==========
== CUDA ==
==========

CUDA Version 12.6.3

Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

This container image and its contents are governed by the NVIDIA Deep Learning Container License.
By pulling and using the container, you accept the terms and conditions of this license:
https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license

A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.
```
`__thrust_exec_check_disable__` is not found.


```
$ docker run -it nvidia/cuda:12.6.3-cudnn-devel-ubuntu20.04 -- bash -c "grep 'define _CCCL_EXEC_CHECK_DISABLE' -r /usr/local/cuda/*/*/include"

(snip)

/usr/local/cuda/targets/x86_64-linux/include/cuda/std/__cccl/execution_space.h:#      define _CCCL_EXEC_CHECK_DISABLE __pragma("nv_exec_check_disable")
/usr/local/cuda/targets/x86_64-linux/include/cuda/std/__cccl/execution_space.h:#      define _CCCL_EXEC_CHECK_DISABLE _Pragma("nv_exec_check_disable")
/usr/local/cuda/targets/x86_64-linux/include/cuda/std/__cccl/execution_space.h:#    define _CCCL_EXEC_CHECK_DISABLE
```
`_CCCL_EXEC_CHECK_DISABLE` is found.

So, it would be more robust to check the existence of `_CCCL_EXEC_CHECK_DISABLE` and `__thrust_exec_check_disable__` with `ifdef` .


## C++17
In addition, recent Pytorch versions require C++17 and I think it's safe to migrate the entire dietgpu project to C++17.